### PR TITLE
refactor: store only ui prefs

### DIFF
--- a/client/src/components/LanguageSwitcher.tsx
+++ b/client/src/components/LanguageSwitcher.tsx
@@ -1,10 +1,16 @@
-import React from 'react';
+import React, {useEffect} from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from './ui/button';
 import { Globe } from 'lucide-react';
+import {useAppStore} from '../stores/useAppStore';
 
 export const LanguageSwitcher: React.FC = () => {
   const { i18n, t } = useTranslation();
+  const setLanguage = useAppStore((state) => state.setLanguage);
+
+  useEffect(() => {
+    setLanguage(i18n.language);
+  }, [i18n.language, setLanguage]);
 
   const toggleLanguage = () => {
     const newLang = i18n.language === 'ar' ? 'en' : 'ar';
@@ -16,6 +22,7 @@ export const LanguageSwitcher: React.FC = () => {
     
     // Store language preference in localStorage
     localStorage.setItem('i18nextLng', newLang);
+    setLanguage(newLang);
   };
 
   const currentLanguage = i18n.language === 'ar' ? 'العربية' : 'English';

--- a/client/src/components/theme-provider.tsx
+++ b/client/src/components/theme-provider.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
+import {useAppStore} from '../stores/useAppStore';
 
 type Theme = 'dark' | 'light' | 'system';
 
@@ -26,7 +27,7 @@ export function ThemeProvider ({
   storageKey = 'vite-ui-theme',
   ...props
 }: ThemeProviderProps) {
-
+  const setGlobalTheme = useAppStore((state) => state.setTheme);
   const [theme, setTheme] = useState<Theme>(() => {
     if (typeof window === 'undefined') {
       return defaultTheme;
@@ -57,6 +58,10 @@ export function ThemeProvider ({
 
   }, [theme]);
 
+  useEffect(() => {
+    setGlobalTheme(theme);
+  }, [theme, setGlobalTheme]);
+
   const value = {
     theme,
     'setTheme': (theme: Theme) => {
@@ -64,6 +69,7 @@ export function ThemeProvider ({
         window.localStorage.setItem(storageKey, theme);
       }
       setTheme(theme);
+      setGlobalTheme(theme);
     }
   };
 

--- a/client/src/lib/logger-ui.tsx
+++ b/client/src/lib/logger-ui.tsx
@@ -1,6 +1,7 @@
 // Internal Logging System for HRMS Elite
 import React from 'react';
 import { logger as baseLogger } from './logger';
+import {useAppStore} from '../stores/useAppStore';
 
 
 interface LogLevel {
@@ -106,12 +107,7 @@ class Logger {
 
   private getCurrentUserId(): string | undefined {
     try {
-      // Get user ID from localStorage or context
-      const user = typeof window !== 'undefined' ? window.localStorage.getItem('hrms-user') : null;
-      if (!user) return undefined;
-      
-      const parsedUser = JSON.parse(user) as { id?: string };
-      return parsedUser.id;
+      return useAppStore.getState().user?.id;
     } catch {
       return undefined;
     }

--- a/client/src/stores/useAppStore.ts
+++ b/client/src/stores/useAppStore.ts
@@ -118,6 +118,8 @@ interface AppState {
   isInitialized: boolean;
   hydrationComplete: boolean;
   lastSyncTime: number | null;
+  theme: 'light' | 'dark' | 'system';
+  language: string;
 
   // Actions
   setUser: (user: DbUser | null) => void;
@@ -128,6 +130,8 @@ interface AppState {
   setInitialized: (initialized: boolean) => void;
   setHydrationComplete: (complete: boolean) => void;
   setLastSyncTime: (time: number | null) => void;
+  setTheme: (theme: 'light' | 'dark' | 'system') => void;
+  setLanguage: (language: string) => void;
 
   // Computed values
   isAuthenticated: boolean;
@@ -202,6 +206,8 @@ export const useAppStore = create<AppState>()(
       'isInitialized': false,
       'hydrationComplete': false,
       'lastSyncTime': null,
+      'theme': 'system',
+      'language': 'en',
 
       // Actions
       'setUser': (user) => set({user}),
@@ -212,6 +218,8 @@ export const useAppStore = create<AppState>()(
       'setInitialized': (initialized) => set({'isInitialized': initialized}),
       'setHydrationComplete': (complete) => set({'hydrationComplete': complete}),
       'setLastSyncTime': (time) => set({'lastSyncTime': time}),
+      'setTheme': (theme) => set({theme}),
+      'setLanguage': (language) => set({'language': language}),
 
       // Computed values
       get 'isAuthenticated' () {
@@ -694,10 +702,9 @@ export const useAppStore = create<AppState>()(
     {
       'name': 'hrms-app-store', // unique name for localStorage
       'partialize': (state) => ({
-        'user': state.user,
-        'company': state.company,
-        'lastSyncTime': state.lastSyncTime
-      }), // persist user, compunknown, and last sync time
+        'theme': state.theme,
+        'language': state.language
+      }), // persist only non-sensitive UI preferences
       'onRehydrateStorage': () => (state) => {
 
         // Called when hydration starts
@@ -728,6 +735,8 @@ export const useIsInitialized = () => useAppStore((state) => state.isInitialized
 export const useHydrationComplete = () => useAppStore((state) => state.hydrationComplete);
 export const useIsDataStale = () => useAppStore((state) => state.isDataStale());
 export const useLastSyncTime = () => useAppStore((state) => state.lastSyncTime);
+export const useAppTheme = () => useAppStore((state) => state.theme);
+export const useAppLanguage = () => useAppStore((state) => state.language);
 
 // New hooks for simplified API operations
 export const useAPIOperations = () => useAppStore((state) => ({


### PR DESCRIPTION
## Summary
- ensure Zustand store persistence keeps only theme and language
- avoid storing PII in logger by sourcing user id from in-memory state
- sync theme and language changes with central store

## Testing
- `npm test` *(fails: tsx not found)*
- `npm install --legacy-peer-deps` *(fails: 403 Forbidden fetching @journeyapps/sqlcipher)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e499215c8325a33f79743f5cbe88