### PR TITLE
feat: enforce sqlcipher encryption

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "db:test-restore": "tsx server/utils/dbBackup.ts --test-restore",
     "db:security-status": "tsx server/utils/dbSecurity.ts --status",
     "db:mask-data": "tsx server/utils/dataMasking.ts --mask",
+    "db:migrate-encryption": "node scripts/migrate-sqlite-encryption.js",
     "quality:check": "node scripts/quality-monitor.js",
     "quality:report": "npm run quality:check && cat quality-report.json",
     "quality:dashboard": "npm run quality:check && echo 'Quality report generated. View at quality-report.json'",

--- a/scripts/migrate-sqlite-encryption.js
+++ b/scripts/migrate-sqlite-encryption.js
@@ -1,0 +1,37 @@
+// Migration script to encrypt or re-encrypt an existing SQLite database
+// Usage: DB_ENCRYPTION_KEY=newkey [DB_ENCRYPTION_KEY_PREVIOUS=oldkey] node scripts/migrate-sqlite-encryption.js [dbPath]
+
+import SQLCipher from '@journeyapps/sqlcipher';
+import fs from 'fs';
+import path from 'path';
+
+const dbPath = process.argv[2] || process.env.DATABASE_URL || 'dev.db';
+const newKey = process.env.DB_ENCRYPTION_KEY;
+const oldKey = process.env.DB_ENCRYPTION_KEY_PREVIOUS || '';
+
+if (!newKey || newKey.length < 32) {
+  console.error('DB_ENCRYPTION_KEY must be at least 32 characters long');
+  process.exit(1);
+}
+
+const resolvedPath = path.resolve(dbPath);
+if (!fs.existsSync(resolvedPath)) {
+  console.error(`Database file not found at ${resolvedPath}`);
+  process.exit(1);
+}
+
+const db = new SQLCipher(resolvedPath);
+try {
+  // Open database with old key or as unencrypted
+  db.pragma(`key = '${oldKey}'`);
+  // Verify that the database is accessible
+  db.prepare('SELECT 1').get();
+  // Rekey database with new encryption key
+  db.pragma(`rekey = '${newKey}'`);
+  console.log('Database encryption migrated successfully');
+} catch (err) {
+  console.error('Failed to migrate database encryption:', err.message);
+  process.exit(1);
+} finally {
+  db.close();
+}

--- a/server/models/db-optimized.ts
+++ b/server/models/db-optimized.ts
@@ -1,11 +1,19 @@
-import {drizzle} from 'drizzle-orm/better-sqlite3';
-import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import SQLCipher from '@journeyapps/sqlcipher';
 import * as optimizedSchema from '@shared/schema/optimized-schema';
-import 'dotenv/config';
+import { env } from '../utils/env';
 
 // Use DATABASE_URL if set, otherwise default to dev.db
-const dbPath = process.env.DATABASE_URL || 'dev.db';
-const sqlite = new Database(dbPath);
+const dbPath = env.DATABASE_URL || 'dev.db';
+
+// Fail fast if encryption key is missing or too short
+if (!env.DB_ENCRYPTION_KEY || env.DB_ENCRYPTION_KEY.length < 32) {
+  throw new Error('DB_ENCRYPTION_KEY must be at least 32 characters long');
+}
+
+// Initialize encrypted database
+const sqlite = new SQLCipher(dbPath);
+sqlite.pragma(`key = '${env.DB_ENCRYPTION_KEY}'`);
 
 // Enable WAL mode for better performance
 sqlite.pragma('journal_mode = WAL');

--- a/server/models/db.ts
+++ b/server/models/db.ts
@@ -1,9 +1,18 @@
-import {drizzle} from 'drizzle-orm/better-sqlite3';
-import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import SQLCipher from '@journeyapps/sqlcipher';
 import * as schema from '@shared/schema';
-import 'dotenv/config';
+import { env } from '../utils/env';
 
 // Use DATABASE_URL if set, otherwise default to dev.db
-const dbPath = process.env.DATABASE_URL || 'dev.db';
-const sqlite = new Database(dbPath);
-export const db = drizzle(sqlite, {schema});
+const dbPath = env.DATABASE_URL || 'dev.db';
+
+// Fail fast if encryption key is missing or too short
+if (!env.DB_ENCRYPTION_KEY || env.DB_ENCRYPTION_KEY.length < 32) {
+  throw new Error('DB_ENCRYPTION_KEY must be at least 32 characters long');
+}
+
+// Initialize encrypted database
+const sqlite = new SQLCipher(dbPath);
+sqlite.pragma(`key = '${env.DB_ENCRYPTION_KEY}'`);
+
+export const db = drizzle(sqlite, { schema });


### PR DESCRIPTION
## Summary
- secure database initialization by requiring SQLCipher with a strong `DB_ENCRYPTION_KEY`
- add npm utility to migrate existing SQLite databases to encrypted form

## Testing
- `npm install --legacy-peer-deps` *(fails: building @journeyapps/sqlcipher)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e675dd0c8325a1938631e3124125