### PR TITLE
ci: add accessibility and performance checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,11 +109,10 @@ jobs:
         env:
           NODE_ENV: test
 
-      - name: Run accessibility tests
+      - name: Run axe-core accessibility tests
         run: npm run test:accessibility
         env:
           NODE_ENV: test
-        continue-on-error: true
 
       - name: Upload test coverage
         uses: codecov/codecov-action@v4
@@ -188,6 +187,12 @@ jobs:
         run: npm run build
         env:
           NODE_ENV: production
+
+      - name: Check bundle size
+        run: node client/scripts/check-bundle-size.mjs
+
+      - name: Run Lighthouse CI
+        run: npx lhci autorun
 
       - name: Build Electron app
         run: npm run build:electron

--- a/.lighthouserc.json
+++ b/.lighthouserc.json
@@ -15,7 +15,7 @@
     },
     "assert": {
       "assertions": {
-        "categories:performance": ["warn", {"minScore": 0.8}],
+        "categories:performance": ["warn", {"minScore": 0.85}],
         "categories:accessibility": ["error", {"minScore": 0.9}],
         "categories:best-practices": ["warn", {"minScore": 0.8}],
         "categories:seo": ["warn", {"minScore": 0.8}],


### PR DESCRIPTION
## Summary
- run axe-core accessibility tests in CI
- enforce bundle size budgets and run Lighthouse CI with perf >=85 / a11y >=90

## Testing
- `npm test` *(fails: Cannot find package 'tsx')*
- `npm ci --legacy-peer-deps` *(fails: @journeyapps/sqlcipher build error)*

------
https://chatgpt.com/codex/tasks/task_e_68a6eb277cc88325a2b0d1c134483d8a