### PR TITLE
chore: add deployment verification and runbooks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -380,6 +380,50 @@ jobs:
           echo "❌ Production deployment failed!"
           # Add notification logic
 
+  # ✅ Deployment Verification Checklist
+  deploy-checklist:
+    name: Deployment Verification Checklist
+    runs-on: ubuntu-latest
+    needs: deploy-production
+    if: github.ref == 'refs/heads/main' || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'production')
+    env:
+      PRODUCTION_DOMAIN: hrms-elite.com
+    steps:
+      - name: Verify TLS certificate
+        run: |
+          echo "Verifying TLS certificate for $PRODUCTION_DOMAIN..."
+          if ! openssl s_client -connect $PRODUCTION_DOMAIN:443 -servername $PRODUCTION_DOMAIN </dev/null 2>/dev/null | openssl x509 -noout -checkend 0; then
+            echo "TLS certificate validation failed"
+            exit 1
+          fi
+
+      - name: Check HSTS preload
+        run: |
+          echo "Checking HSTS preload header..."
+          if ! curl -fsSLI https://$PRODUCTION_DOMAIN | grep -i 'strict-transport-security' | grep -qi 'preload'; then
+            echo "HSTS preload not enabled"
+            exit 1
+          fi
+
+      - name: Verify backups
+        run: |
+          echo "Ensuring backup files are present..."
+          if [ -z "$(ls -A backups 2>/dev/null)" ]; then
+            echo "No backups found"
+            exit 1
+          fi
+          ls -l backups | head -n 5
+
+      - name: Run restore drill
+        run: |
+          echo "Running backup restore drill..."
+          LATEST_DB_BACKUP=$(ls -t backups/database/*.db 2>/dev/null | head -n 1)
+          if [ -z "$LATEST_DB_BACKUP" ]; then
+            echo "No database backup available for restore test"
+            exit 1
+          fi
+          sqlite3 :memory: ".restore $LATEST_DB_BACKUP"
+
   # 📱 Mobile App Build & Deploy
   mobile-build:
     name: Mobile App Build & Deploy

--- a/docs/BACKUP-RESTORE-RUNBOOK.md
+++ b/docs/BACKUP-RESTORE-RUNBOOK.md
@@ -1,0 +1,33 @@
+# Backup and Restore Runbook
+
+Step-by-step instructions to verify backups and perform restore drills.
+
+## Verify Recent Backups
+1. List backup files and confirm a recent timestamp:
+```bash
+ls -l backups/
+```
+2. Check automated backup workflow status in GitHub Actions or your scheduler.
+
+## Manual Backup
+Run a manual backup when needed:
+```bash
+npm run db:backup
+```
+
+## Restore Drill
+1. Select the latest backup file:
+```bash
+LATEST=$(ls -t backups/database/*.db | head -n 1)
+```
+2. Restore to a temporary database and validate integrity:
+```bash
+sqlite3 :memory: ".restore $LATEST"
+sqlite3 :memory: "PRAGMA integrity_check;"
+```
+3. Document results and clean up temporary files.
+
+## Best Practices
+- Store `DB_BACKUP_ENCRYPTION_KEY` securely and keep backups off-site.
+- Test restore procedures regularly (at least quarterly).
+- After any incident, perform a full backup and verify it.

--- a/docs/INCIDENT-RESPONSE.md
+++ b/docs/INCIDENT-RESPONSE.md
@@ -1,0 +1,26 @@
+# Incident Response Guide
+
+Use this guide to handle production incidents quickly and consistently.
+
+## 1. Preparation
+- Keep on-call and escalation contacts up to date.
+- Ensure monitoring, alerts, and backups are functioning.
+
+## 2. Identification
+- Confirm the incident via alerts or user reports.
+- Capture timestamps, logs, metrics, and recent changes.
+
+## 3. Containment
+- Limit blast radius: disable affected features or reroute traffic.
+- Preserve evidence for later analysis.
+
+## 4. Eradication and Recovery
+- Fix or roll back the offending change.
+- If data is impacted, restore from the latest good backup.
+- Validate services with health checks and smoke tests.
+
+## 5. Post-Incident
+- Document root cause, timeline, and remediation steps.
+- Create follow-up issues for long-term fixes and add tests or alerts.
+
+Maintain and review this guide regularly so the team is ready for the next incident.


### PR DESCRIPTION
## Summary
- add deployment checklist job verifying TLS cert, HSTS preload, and backup restore
- document incident response procedures
- add backup/restore runbook

## Testing
- `npm ci --legacy-peer-deps` *(fails: node-pre-gyp install response status 403 Forbidden on sqlcipher)*

------
https://chatgpt.com/codex/tasks/task_e_68a6ed2aece08325ab205db80450aa92