### PR TITLE
feat: improve i18n localization

### DIFF
--- a/client/src/components/LanguageSwitcher.tsx
+++ b/client/src/components/LanguageSwitcher.tsx
@@ -25,8 +25,10 @@ export const LanguageSwitcher: React.FC = () => {
     setLanguage(newLang);
   };
 
-  const currentLanguage = i18n.language === 'ar' ? 'العربية' : 'English';
-  const nextLanguage = i18n.language === 'ar' ? 'English' : 'العربية';
+    const currentLanguage = t(`languages.${i18n.language === 'ar' ? 'arabic' : 'english'}`);
+    const nextLanguageKey = i18n.language === 'ar' ? 'english' : 'arabic';
+    const nextLanguage = t(`languages.${nextLanguageKey}`);
+    const nextLanguageShort = t(`languages.short.${nextLanguageKey}`);
 
   return (
     <Button
@@ -37,8 +39,8 @@ export const LanguageSwitcher: React.FC = () => {
       title={`${t('settings.language')}: ${currentLanguage}`}
     >
       <Globe className="h-4 w-4" />
-      <span className="hidden sm:inline">{nextLanguage}</span>
-      <span className="sm:hidden">{i18n.language === 'ar' ? 'EN' : 'عربي'}</span>
-    </Button>
-  );
-};
+        <span className="hidden sm:inline">{nextLanguage}</span>
+        <span className="sm:hidden">{nextLanguageShort}</span>
+      </Button>
+    );
+  };

--- a/client/src/components/shared/EnhancedErrorBoundary.tsx
+++ b/client/src/components/shared/EnhancedErrorBoundary.tsx
@@ -5,9 +5,10 @@ import {Card, CardContent, CardHeader, CardTitle} from '../ui/card';
 import {Badge} from '../ui/badge';
 import {Separator} from '../ui/separator';
 import logger from '../../lib/logger';
+import { withTranslation, WithTranslation, useTranslation } from 'react-i18next';
 
 
-interface Props {
+interface Props extends WithTranslation {
   children: ReactNode;
   fallback?: ReactNode;
   onError?: (error: Error, errorInfo: ErrorInfo) => void;
@@ -24,48 +25,54 @@ interface State {
 }
 
 // Loading fallback component
-const LoadingFallback = () => (
-  <div className="min-h-screen bg-background flex items-center justify-center p-4">
-    <Card className="w-full max-w-md">
-      <CardContent className="flex items-center justify-center p-6">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
-        <span className="mr-3 text-muted-foreground">جاري التحميل...</span>
-      </CardContent>
-    </Card>
-  </div>
-);
+const LoadingFallback = () => {
+  const { t } = useTranslation();
+  return (
+    <div className="min-h-screen bg-background flex items-center justify-center p-4">
+      <Card className="w-full max-w-md">
+        <CardContent className="flex items-center justify-center p-6">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
+          <span className="mr-3 text-muted-foreground">{t('common.loading')}</span>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
 
 // Error details component with React.memo for performance
-const ErrorDetails = React.memo(({error, errorInfo}: { error: Error; errorInfo?: ErrorInfo | undefined }) => (
-  <details className="bg-muted p-4 rounded-lg text-sm space-y-3">
-    <summary className="cursor-pointer font-medium mb-3 flex items-center gap-2">
-      <Bug className="h-4 w-4" />
-      تفاصيل الخطأ (للطور)
-    </summary>
-    <div className="space-y-3">
-      <div>
-        <strong className="text-destructive">الخطأ:</strong>
-        <pre className="mt-2 text-xs bg-background p-3 rounded overflow-auto border">
-          {error.message}
-        </pre>
-      </div>
-      {errorInfo && (
+const ErrorDetails = React.memo(({error, errorInfo}: { error: Error; errorInfo?: ErrorInfo | undefined }) => {
+  const { t } = useTranslation();
+  return (
+    <details className="bg-muted p-4 rounded-lg text-sm space-y-3">
+      <summary className="cursor-pointer font-medium mb-3 flex items-center gap-2">
+        <Bug className="h-4 w-4" />
+        {t('errors.details')}
+      </summary>
+      <div className="space-y-3">
         <div>
-          <strong className="text-destructive">معلومات إضافية:</strong>
+          <strong className="text-destructive">{t('errors.errorLabel')}</strong>
           <pre className="mt-2 text-xs bg-background p-3 rounded overflow-auto border">
-            {errorInfo.componentStack}
+            {error.message}
           </pre>
         </div>
-      )}
-      <div>
-        <strong className="text-destructive">Stack Trace:</strong>
-        <pre className="mt-2 text-xs bg-background p-3 rounded overflow-auto border">
-          {error.stack}
-        </pre>
+        {errorInfo && (
+          <div>
+            <strong className="text-destructive">{t('errors.additionalInfo')}</strong>
+            <pre className="mt-2 text-xs bg-background p-3 rounded overflow-auto border">
+              {errorInfo.componentStack}
+            </pre>
+          </div>
+        )}
+        <div>
+          <strong className="text-destructive">Stack Trace:</strong>
+          <pre className="mt-2 text-xs bg-background p-3 rounded overflow-auto border">
+            {error.stack}
+          </pre>
+        </div>
       </div>
-    </div>
-  </details>
-));
+    </details>
+  );
+});
 
 ErrorDetails.displayName = 'ErrorDetails';
 
@@ -192,7 +199,7 @@ export class EnhancedErrorBoundary extends Component<Props, State> {
       // In a real application, you would send this to your support system
 
       // Show success message
-      window.alert('تم إرسال تقرير الخطأ بنجاح');
+      window.alert(this.props.t('errors.sent'));
 
     }
 
@@ -211,6 +218,7 @@ export class EnhancedErrorBoundary extends Component<Props, State> {
 
       const {error, errorInfo, retryCount} = this.state;
 
+      const { t } = this.props;
       return (
         <div className="min-h-screen bg-background flex items-center justify-center p-4">
           <Card className="w-full max-w-lg">
@@ -219,16 +227,16 @@ export class EnhancedErrorBoundary extends Component<Props, State> {
                 <AlertTriangle className="h-8 w-8 text-red-600 dark:text-red-400" />
               </div>
               <CardTitle className="text-xl text-red-600 dark:text-red-400">
-                حدث خطأ غير متوقع
+                {t('errors.unexpected')}
               </CardTitle>
               <p className="text-sm text-muted-foreground mt-2">
-                عذراً، حدث خطأ أثناء تحميل هذه الصفحة
+                {t('errors.pageLoad')}
               </p>
             </CardHeader>
             <CardContent className="space-y-4">
               <div className="flex items-center justify-center gap-2">
                 <Badge variant="outline" className="text-xs">
-                  محاولة {retryCount + 1}
+                  {t('errors.retryAttempt', { count: retryCount + 1 })}
                 </Badge>
                 {error && (
                   <Badge variant="destructive" className="text-xs">
@@ -238,8 +246,7 @@ export class EnhancedErrorBoundary extends Component<Props, State> {
               </div>
 
               <p className="text-muted-foreground text-center text-sm">
-                يرجى المحاولة مرة أخرى أو العودة إلى الصفحة الرئيسية. إذا استمرت المشكلة،
-                يمكنك الإبلاغ عن الخطأ للمساعدة في حلها.
+                {t('errors.tryAgainOrHome')}
               </p>
 
               {/* Error details for development */}
@@ -256,7 +263,7 @@ export class EnhancedErrorBoundary extends Component<Props, State> {
                   variant="default"
                 >
                   <RefreshCw className="h-4 w-4" />
-                  إعادة المحاولة
+                  {t('errors.retry')}
                 </Button>
                 <Button
                   onClick={this.handleGoHome}
@@ -264,7 +271,7 @@ export class EnhancedErrorBoundary extends Component<Props, State> {
                   variant="outline"
                 >
                   <Home className="h-4 w-4" />
-                  الصفحة الرئيسية
+                  {t('errors.home')}
                 </Button>
               </div>
 
@@ -276,7 +283,7 @@ export class EnhancedErrorBoundary extends Component<Props, State> {
                   size="sm"
                 >
                   <RefreshCw className="h-4 w-4" />
-                  إعادة تحميل الصفحة
+                  {t('errors.reload')}
                 </Button>
                 <Button
                   onClick={this.handleReportError}
@@ -285,7 +292,7 @@ export class EnhancedErrorBoundary extends Component<Props, State> {
                   size="sm"
                 >
                   <Info className="h-4 w-4" />
-                  الإبلاغ عن الخطأ
+                  {t('errors.report')}
                 </Button>
               </div>
             </CardContent>
@@ -307,15 +314,17 @@ export class EnhancedErrorBoundary extends Component<Props, State> {
 }
 
 // HOC for wrapping components with error boundary
+const TranslatedErrorBoundary = withTranslation()(EnhancedErrorBoundary);
+
 export const withErrorBoundary = <P extends object>(
   Component: React.ComponentType<P>,
   errorBoundaryProps?: Omit<Props, 'children'>
 ) => {
 
   const WrappedComponent = (props: P) => (
-    <EnhancedErrorBoundary {...errorBoundaryProps}>
+    <TranslatedErrorBoundary {...errorBoundaryProps}>
       <Component {...props} />
-    </EnhancedErrorBoundary>
+    </TranslatedErrorBoundary>
   );
 
   WrappedComponent.displayName = `withErrorBoundary(${Component.displayName ?? Component.name})`;
@@ -323,4 +332,4 @@ export const withErrorBoundary = <P extends object>(
 
 };
 
-export default EnhancedErrorBoundary;
+export default TranslatedErrorBoundary;

--- a/client/src/lib/i18n.ts
+++ b/client/src/lib/i18n.ts
@@ -16,11 +16,11 @@ const resources = {
   }
 };
 
-i18n
-  .use(Backend)
-  .use(LanguageDetector)
-  .use(initReactI18next)
-  .init({
+  i18n
+    .use(Backend)
+    .use(LanguageDetector)
+    .use(initReactI18next)
+    .init({
     resources,
     fallbackLng: 'en',
     debug: process.env.NODE_ENV === 'development',
@@ -41,7 +41,25 @@ i18n
     // RTL support
     dir: (lng) => {
       return lng === 'ar' ? 'rtl' : 'ltr';
-    }
-  });
+      }
+    });
+
+// Custom pluralization rules for English and Arabic
+i18n.services.pluralResolver.addRule('en', {
+  numbers: [1, 2],
+  plurals: n => Number(n !== 1)
+});
+
+i18n.services.pluralResolver.addRule('ar', {
+  numbers: [0, 1, 2, 3, 11, 100],
+  plurals: n => {
+    if (n === 0) return 0;
+    if (n === 1) return 1;
+    if (n === 2) return 2;
+    if (n % 100 >= 3 && n % 100 <= 10) return 3;
+    if (n % 100 >= 11 && n % 100 <= 99) return 4;
+    return 5;
+  }
+});
 
 export default i18n;

--- a/client/src/locales/ar.json
+++ b/client/src/locales/ar.json
@@ -49,6 +49,14 @@
     "aiAnalytics": "التحليلات الذكية",
     "aiChatbot": "المساعد الذكي"
   },
+  "languages": {
+    "english": "English",
+    "arabic": "العربية",
+    "short": {
+      "english": "EN",
+      "arabic": "عربي"
+    }
+  },
   "accessibility": {
     "skipNavigation": "تخطي التنقل",
     "skipToMainContent": "تخطي إلى المحتوى الرئيسي",
@@ -370,6 +378,30 @@
     "noData": "لا توجد بيانات متاحة",
     "loadingData": "جاري تحميل البيانات...",
     "errorLoadingData": "خطأ في تحميل البيانات"
+  },
+  "forms": {
+    "username": "اسم المستخدم",
+    "password": "كلمة المرور",
+    "submit": "إرسال"
+  },
+  "errors": {
+    "details": "تفاصيل الخطأ (للطور)",
+    "errorLabel": "الخطأ:",
+    "additionalInfo": "معلومات إضافية:",
+    "unexpected": "حدث خطأ غير متوقع",
+    "pageLoad": "عذراً، حدث خطأ أثناء تحميل هذه الصفحة",
+    "tryAgainOrHome": "يرجى المحاولة مرة أخرى أو العودة إلى الصفحة الرئيسية. إذا استمرت المشكلة، يمكنك الإبلاغ عن الخطأ للمساعدة في حله.",
+    "retry": "إعادة المحاولة",
+    "home": "الصفحة الرئيسية",
+    "reload": "إعادة تحميل الصفحة",
+    "report": "الإبلاغ عن الخطأ",
+    "sent": "تم إرسال تقرير الخطأ بنجاح",
+    "retryAttempt_zero": "لم تتم أي محاولة",
+    "retryAttempt_one": "محاولة واحدة",
+    "retryAttempt_two": "محاولتان",
+    "retryAttempt_few": "{{count}} محاولات",
+    "retryAttempt_many": "{{count}} محاولة",
+    "retryAttempt_other": "{{count}} محاولة"
   },
   "dateTime": {
     "today": "اليوم",

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -49,6 +49,14 @@
     "aiAnalytics": "AI Analytics",
     "aiChatbot": "AI Chatbot"
   },
+  "languages": {
+    "english": "English",
+    "arabic": "Arabic",
+    "short": {
+      "english": "EN",
+      "arabic": "عربي"
+    }
+  },
   "accessibility": {
     "skipNavigation": "Skip Navigation",
     "skipToMainContent": "Skip to main content",
@@ -370,6 +378,26 @@
     "noData": "No data available",
     "loadingData": "Loading data...",
     "errorLoadingData": "Error loading data"
+  },
+  "forms": {
+    "username": "Username",
+    "password": "Password",
+    "submit": "Submit"
+  },
+  "errors": {
+    "details": "Error details (dev)",
+    "errorLabel": "Error:",
+    "additionalInfo": "Additional Info:",
+    "unexpected": "An unexpected error occurred",
+    "pageLoad": "Sorry, an error occurred while loading this page",
+    "tryAgainOrHome": "Please try again or return to the homepage. If the problem persists, you can report the error to help resolve it.",
+    "retry": "Retry",
+    "home": "Home",
+    "reload": "Reload Page",
+    "report": "Report Error",
+    "sent": "Error report sent successfully",
+    "retryAttempt_one": "Attempt {{count}}",
+    "retryAttempt_other": "Attempt {{count}}"
   },
   "dateTime": {
     "today": "Today",


### PR DESCRIPTION
## Summary
- externalize language switcher labels
- add pluralization rules and new error translations
- provide form and error locales for English and Arabic

## Testing
- `npm test` *(fails: Cannot find package 'tsx')*
- `npm install --legacy-peer-deps` *(fails: sqlcipher build error)*

------
https://chatgpt.com/codex/tasks/task_e_68a6ee81f4508325b4a5992bc97ab709