### PR TITLE
feat: dynamic document direction based on language

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,6 +7,7 @@ import { ReactQueryDevTools } from './components/shared/ReactQueryDevTools';
 import { AccessibilityProvider } from './components/shared/AccessibilityProvider';
 import { queryClient } from './lib/queryClient';
 import { useRoleBasedPreloading } from './hooks/useLazyLoading';
+import { useDirection } from './hooks/useDirection';
 import { Toaster } from './components/ui/toaster';
 import { NotFound } from './pages/lazy-pages';
 
@@ -18,6 +19,7 @@ const App = () => {
   const { user } = useAppStore();
   const isAuthenticated = !!user;
   useRoleBasedPreloading(user?.role ?? undefined);
+  useDirection();
 
   return (
     <QueryClientProvider client={queryClient}>

--- a/client/src/components/shared/PageHelmet.tsx
+++ b/client/src/components/shared/PageHelmet.tsx
@@ -76,9 +76,6 @@ export function PageHelmet ({
       <meta name="apple-mobile-web-app-capable" content="yes" />
       <meta name="apple-mobile-web-app-status-bar-style" content="default" />
 
-      {/* Language and Direction */}
-      <html lang="ar" dir="rtl" />
-
       {children}
     </Helmet>
   );

--- a/client/src/hooks/useDirection.ts
+++ b/client/src/hooks/useDirection.ts
@@ -1,0 +1,16 @@
+import { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+
+/**
+ * Hook to update the document direction and language based on i18n settings.
+ * Sets `<html dir>` and `<html lang>` whenever the active language changes.
+ */
+export function useDirection(): void {
+  const { i18n } = useTranslation();
+
+  useEffect(() => {
+    const dir = i18n.dir();
+    document.documentElement.setAttribute('dir', dir);
+    document.documentElement.setAttribute('lang', i18n.language);
+  }, [i18n.language, i18n]);
+}

--- a/client/src/pages/advanced-search.tsx
+++ b/client/src/pages/advanced-search.tsx
@@ -775,7 +775,7 @@ export default function AdvancedSearchPage () {
   };
 
   return (
-    <div className="min-h-screen bg-background" dir="rtl">
+    <div className="min-h-screen bg-background">
       <header className="bg-card shadow-sm border-b">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center py-4">

--- a/client/src/pages/company-selection.tsx
+++ b/client/src/pages/company-selection.tsx
@@ -156,7 +156,7 @@ export default function CompanySelection () {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-purple-50" dir="rtl">
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-purple-50">
       <div className="container mx-auto px-4 py-12">
         {/* Header */}
         <div className="text-center mb-12">

--- a/client/src/pages/super-admin-dashboard.tsx
+++ b/client/src/pages/super-admin-dashboard.tsx
@@ -64,7 +64,7 @@ function SuperAdminContent () {
   };
 
   return (
-    <div className="min-h-screen bg-background" dir="rtl">
+    <div className="min-h-screen bg-background">
       <header className="bg-card shadow-sm border-b">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center py-4">


### PR DESCRIPTION
## Summary
- add `useDirection` hook to set `<html dir>`/`lang` according to i18n language
- invoke direction hook in `App` and remove hardcoded RTL wrappers
- drop static `<html>` tag from `PageHelmet` for dynamic direction support

## Testing
- `npm test` *(fails: Cannot find package 'tsx')*


------
https://chatgpt.com/codex/tasks/task_e_68a71c9f820c832595dfc330200de957