### PR TITLE
feat: secure persistent session handling

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -8,10 +8,8 @@
 
 import express from 'express';
 import cors from 'cors';
-import session from 'express-session';
 import cookieParser from 'cookie-parser';
-import { RedisStore } from 'connect-redis';
-import Redis from 'ioredis';
+import { createSessionMiddleware } from './utils/session';
 
 // Import observability middleware
 import { observability } from './middleware/observability';
@@ -86,26 +84,7 @@ app.use(express.json({ limit: '10mb' }));
 app.use(express.urlencoded({ extended: true, limit: '10mb' }));
 
 // Session configuration with Redis store
-const redisClient = new Redis(env.REDIS_URL || 'redis://localhost:6379');
-const sessionStore = new RedisStore({ client: redisClient });
-
-redisClient.on('error', (err) => {
-  log.error('Redis connection error', { error: err }, 'SERVER');
-});
-
-app.use(session({
-  store: sessionStore,
-  secret: env.SESSION_SECRET,
-  resave: false,
-  saveUninitialized: false,
-  name: env.NODE_ENV === 'production' ? '__Host-hrms-elite-session' : 'hrms-elite-session',
-  cookie: {
-    secure: env.NODE_ENV === 'production',
-    httpOnly: true,
-    maxAge: 24 * 60 * 60 * 1000, // 24 hours
-    sameSite: 'strict'
-  }
-}));
+app.use(createSessionMiddleware());
 
 // CSRF protection
 app.use(csrfProtection);

--- a/server/utils/replitAuth.ts
+++ b/server/utils/replitAuth.ts
@@ -63,11 +63,13 @@ export function getSession () {
     'store': sessionStore,
     'resave': false,
     'saveUninitialized': false,
+    'name': process.env.NODE_ENV === 'production' ? '__Host-hrms-elite-session' : 'hrms-elite-session',
     'cookie': {
       'httpOnly': true,
       'secure': true,
       'sameSite': 'strict',
-      'maxAge': sessionTtl
+      'maxAge': sessionTtl,
+      'path': '/' 
     }
   });
 

--- a/server/utils/session.ts
+++ b/server/utils/session.ts
@@ -1,0 +1,29 @@
+import session from 'express-session';
+import { RedisStore } from 'connect-redis';
+import Redis from 'ioredis';
+import { env } from './env';
+import { log } from './logger';
+
+export function createSessionMiddleware() {
+  const redisClient = new Redis(env.REDIS_URL || 'redis://localhost:6379');
+  const store = new RedisStore({ client: redisClient });
+
+  redisClient.on('error', (err) => {
+    log.error('Redis connection error', { error: err }, 'SESSION');
+  });
+
+  return session({
+    store,
+    secret: env.SESSION_SECRET,
+    resave: false,
+    saveUninitialized: false,
+    name: env.NODE_ENV === 'production' ? '__Host-hrms-elite-session' : 'hrms-elite-session',
+    cookie: {
+      secure: true,
+      httpOnly: true,
+      sameSite: 'strict',
+      maxAge: 24 * 60 * 60 * 1000,
+      path: '/',
+    },
+  });
+}

--- a/tests/session-persistence.test.ts
+++ b/tests/session-persistence.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawn, ChildProcessWithoutNullStreams } from 'child_process';
+import Redis from 'ioredis';
+import { RedisStore } from 'connect-redis';
+
+const port = 6390;
+let redisProcess: ChildProcessWithoutNullStreams;
+
+function setSession(store: RedisStore, sid: string, data: any) {
+  return new Promise<void>((resolve, reject) => {
+    store.set(sid, data, (err) => (err ? reject(err) : resolve()));
+  });
+}
+
+function getSession(store: RedisStore, sid: string) {
+  return new Promise<any>((resolve, reject) => {
+    store.get(sid, (err, session) => (err ? reject(err) : resolve(session)));
+  });
+}
+
+describe('session persistence', () => {
+  beforeAll(async () => {
+    redisProcess = spawn('redis-server', ['--port', port.toString()]);
+    await new Promise((r) => setTimeout(r, 500));
+  });
+
+  afterAll(() => {
+    redisProcess.kill();
+  });
+
+  it('persists sessions across store instances', async () => {
+    const sid = 'testsid';
+    const sessionData = { cookie: { maxAge: 1000 }, userId: 123 };
+
+    const client1 = new Redis(port);
+    const store1 = new RedisStore({ client: client1 });
+    await setSession(store1, sid, sessionData);
+    await client1.quit();
+
+    const client2 = new Redis(port);
+    const store2 = new RedisStore({ client: client2 });
+    const stored = await getSession(store2, sid);
+
+    expect(stored.userId).toBe(123);
+    await client2.quit();
+  });
+});


### PR DESCRIPTION
## Summary
- wrap session logic with reusable Redis-backed middleware and secure cookie flags
- apply hardened session cookie and __Host- prefix in replit OIDC helper
- add test scaffolding to verify Redis session persistence across restarts

## Testing
- `npm test` *(fails: Cannot find package 'tsx')*
- `npx --yes --package ioredis --package connect-redis --package express-session node tests/session-persistence.node.test.mjs` *(fails: Cannot find package 'ioredis')*

------
https://chatgpt.com/codex/tasks/task_e_68a7298d4f108325afc2be71ca499459