### PR TITLE
Use session-backed CSRF tokens with strict cookies

### DIFF
--- a/client/src/lib/apiRequest.ts
+++ b/client/src/lib/apiRequest.ts
@@ -19,7 +19,6 @@ export interface ApiRequestOptions {
   method?: string;
   body?: BodyInitLike | null;
   headers?: HeadersInitLike;
-  useCsrf?: boolean; // Whether to include CSRF token
   responseType?: 'json' | 'text' | 'blob' | 'arrayBuffer' | 'formData';
 }
 
@@ -42,7 +41,7 @@ export const apiRequest = async <T = unknown>(
 
   try {
 
-    const {method = 'GET', body, headers = {}, useCsrf = true, responseType} = options;
+    const {method = 'GET', body, headers = {}, responseType} = options;
 
     // Compute headers; remove Content-Type if sending FormData so the browser can set boundary
     const isFormDataBody = (() => {
@@ -76,10 +75,8 @@ export const apiRequest = async <T = unknown>(
       requestOptions.body = body as BodyInitLike;
     }
 
-    // Use CSRF-protected fetch if enabled
-    const response = useCsrf
-      ? await fetchWithCsrf(url, requestOptions)
-      : await fetch(url, requestOptions);
+    // Always include CSRF token via wrapped fetch
+    const response = await fetchWithCsrf(url, requestOptions);
 
     // Cache ETag header if present
     const etag = response.headers.get('etag');

--- a/server/index.ts
+++ b/server/index.ts
@@ -24,7 +24,7 @@ import {
   enhancedRateLimiters,
   corsConfig
 } from './middleware/security';
-import { csrfProtection, generateCsrfToken, csrfTokenHandler, csrfErrorHandler } from './middleware/csrf';
+import { csrfProtection, csrfTokenMiddleware, csrfTokenHandler, csrfErrorHandler } from './middleware/csrf';
 import { isAuthenticated, optionalAuth } from './middleware/auth';
 import { log } from './utils/logger';
 import { env } from './utils/env';
@@ -88,7 +88,7 @@ app.use(createSessionMiddleware());
 
 // CSRF protection
 app.use(csrfProtection);
-app.use(generateCsrfToken);
+app.use(csrfTokenMiddleware);
 app.get('/api/csrf-token', csrfTokenHandler);
 
 // Rate limiting

--- a/tests/cookie-security.test.ts
+++ b/tests/cookie-security.test.ts
@@ -36,7 +36,7 @@ describe('Cookie Security Tests', () => {
         // Verify security attributes
         expect(sessionCookie).toMatch(/HttpOnly/i);
         expect(sessionCookie).toMatch(/Secure/i);
-        expect(sessionCookie).toMatch(/SameSite=Lax/i);
+        expect(sessionCookie).toMatch(/SameSite=Strict/i);
         expect(sessionCookie).toMatch(/Path=\//);
       } finally {
         process.env.NODE_ENV = originalEnv;
@@ -84,7 +84,7 @@ describe('Cookie Security Tests', () => {
 
         expect(sessionCookie).toBeDefined();
         expect(sessionCookie).toMatch(/HttpOnly/i);
-        expect(sessionCookie).toMatch(/SameSite=Lax/i);
+        expect(sessionCookie).toMatch(/SameSite=Strict/i);
         expect(sessionCookie).toMatch(/Path=\//);
         
         // Should not require secure in development
@@ -116,7 +116,7 @@ describe('Cookie Security Tests', () => {
         if (csrfCookie) {
           expect(csrfCookie).toMatch(/HttpOnly/i);
           expect(csrfCookie).toMatch(/Secure/i);
-          expect(csrfCookie).toMatch(/SameSite=Lax/i);
+          expect(csrfCookie).toMatch(/SameSite=Strict/i);
           expect(csrfCookie).toMatch(/Path=\//);
         }
       } finally {


### PR DESCRIPTION
## Summary
- replace CSRF middleware with session-based `csurf` tokens
- send CSRF token cookie with HttpOnly, Secure and SameSite=Strict
- ensure API request helper always includes CSRF header

## Testing
- `npm run test:server` *(fails: Environment validation failed. Missing or invalid variables; Cannot find module '@journeyapps/sqlcipher'; spawn redis-server ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68a72e80efe48325a1b1ebb9ae762ded