### PR TITLE
chore: add i18n batch extract script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -174,6 +174,8 @@
         "postcss": "8.4.47",
         "prettier": "^3.6.2",
         "tailwindcss": "4.1.11",
+        "ts-morph": "^26.0.0",
+        "ts-node": "^10.9.2",
         "ts-prune": "0.10.3",
         "tsx": "4.20.3",
         "typescript": "5.5.x",
@@ -2606,6 +2608,30 @@
       "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
       "engines": {
         "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -9017,38 +9043,60 @@
       }
     },
     "node_modules/@ts-morph/common": {
-      "version": "0.12.3",
-      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.12.3.tgz",
-      "integrity": "sha512-4tUmeLyXJnJWvTFOKtcNJ1yh0a3SsTLi2MUoyj8iUNznFRN1ZquaNe7Oukqrnki2FzZkm0J9adCNLDZxUzvj+w==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.27.0.tgz",
+      "integrity": "sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "fast-glob": "^3.2.7",
-        "minimatch": "^3.0.4",
-        "mkdirp": "^1.0.4",
+        "fast-glob": "^3.3.3",
+        "minimatch": "^10.0.1",
         "path-browserify": "^1.0.1"
       }
     },
-    "node_modules/@ts-morph/common/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
     "node_modules/@ts-morph/common/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
+      "integrity": "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "@isaacs/brace-expansion": "^5.0.0"
       },
       "engines": {
-        "node": "*"
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.0",
@@ -10345,6 +10393,13 @@
       "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
       "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw=="
     },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -11569,10 +11624,11 @@
       }
     },
     "node_modules/code-block-writer": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-11.0.3.tgz",
-      "integrity": "sha512-NiujjUFB4SwScJq2bwbYUtXbZhBSlY6vYzm++3Q6oC+U+injTqfPYFK8wS9COOmb2lueqp0ZRB4nK1VYeHgNyw==",
-      "dev": true
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-13.0.3.tgz",
+      "integrity": "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/color": {
       "version": "4.2.3",
@@ -11989,6 +12045,13 @@
       "dependencies": {
         "buffer": "^5.1.0"
       }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cross-dirname": {
       "version": "0.1.0",
@@ -12527,6 +12590,16 @@
       "dependencies": {
         "asap": "^2.0.0",
         "wrappy": "1"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/diff-sequences": {
@@ -17659,6 +17732,13 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/make-fetch-happen": {
       "version": "10.2.1",
       "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.2.1.tgz",
@@ -19057,7 +19137,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
       "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -22684,13 +22765,58 @@
       }
     },
     "node_modules/ts-morph": {
-      "version": "13.0.3",
-      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-13.0.3.tgz",
-      "integrity": "sha512-pSOfUMx8Ld/WUreoSzvMFQG5i9uEiWIsBYjpU9+TTASOeUa89j5HykomeqVULm1oqWtBdleI3KEFRLrlA3zGIw==",
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-26.0.0.tgz",
+      "integrity": "sha512-ztMO++owQnz8c/gIENcM9XfCEzgoGphTv+nKpYNM1bgsdOVC/jRZuEBf6N+mLLDNg68Kl+GgUZfOySaRiG1/Ug==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@ts-morph/common": "~0.12.3",
-        "code-block-writer": "^11.0.0"
+        "@ts-morph/common": "~0.27.0",
+        "code-block-writer": "^13.0.3"
+      }
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
       }
     },
     "node_modules/ts-prune": {
@@ -22710,6 +22836,37 @@
         "ts-prune": "lib/index.js"
       }
     },
+    "node_modules/ts-prune/node_modules/@ts-morph/common": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.12.3.tgz",
+      "integrity": "sha512-4tUmeLyXJnJWvTFOKtcNJ1yh0a3SsTLi2MUoyj8iUNznFRN1ZquaNe7Oukqrnki2FzZkm0J9adCNLDZxUzvj+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-glob": "^3.2.7",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^1.0.4",
+        "path-browserify": "^1.0.1"
+      }
+    },
+    "node_modules/ts-prune/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/ts-prune/node_modules/code-block-writer": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-11.0.3.tgz",
+      "integrity": "sha512-NiujjUFB4SwScJq2bwbYUtXbZhBSlY6vYzm++3Q6oC+U+injTqfPYFK8wS9COOmb2lueqp0ZRB4nK1VYeHgNyw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ts-prune/node_modules/commander": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
@@ -22717,6 +22874,30 @@
       "dev": true,
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/ts-prune/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/ts-prune/node_modules/ts-morph": {
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-13.0.3.tgz",
+      "integrity": "sha512-pSOfUMx8Ld/WUreoSzvMFQG5i9uEiWIsBYjpU9+TTASOeUa89j5HykomeqVULm1oqWtBdleI3KEFRLrlA3zGIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ts-morph/common": "~0.12.3",
+        "code-block-writer": "^11.0.0"
       }
     },
     "node_modules/tsconfig-paths": {
@@ -23214,6 +23395,13 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/validator": {
       "version": "13.15.15",
@@ -24774,6 +24962,16 @@
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -291,6 +291,8 @@
     "postcss": "8.4.47",
     "prettier": "^3.6.2",
     "tailwindcss": "4.1.11",
+    "ts-morph": "^26.0.0",
+    "ts-node": "^10.9.2",
     "ts-prune": "0.10.3",
     "tsx": "4.20.3",
     "typescript": "5.5.x",

--- a/scripts/i18n-batch-extract.ts
+++ b/scripts/i18n-batch-extract.ts
@@ -1,0 +1,124 @@
+import { Project, SyntaxKind, Node, SourceFile, FunctionLikeDeclaration } from 'ts-morph';
+import path from 'path';
+import fs from 'fs';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+interface RecordEntry { file: string; original: string }
+
+const LIMIT_ARG = process.argv.find(a => a.startsWith('--limit'));
+const LIMIT = LIMIT_ARG ? parseInt(LIMIT_ARG.split('=')[1], 10) : Infinity;
+
+const project = new Project({ tsConfigFilePath: path.join(__dirname, '../client/tsconfig.json') });
+const sourceFiles = project.addSourceFilesAtPaths('client/src/**/*.tsx');
+
+const arPath = path.join(__dirname, '../client/src/locales/ar.json');
+const enPath = path.join(__dirname, '../client/src/locales/en.json');
+const csvPath = path.join(__dirname, '../audit/i18n/suggested-keys.csv');
+
+function setNested(obj: any, keys: string[], value: string) {
+  let cur = obj;
+  for (let i = 0; i < keys.length - 1; i++) {
+    const k = keys[i];
+    if (!cur[k]) cur[k] = {};
+    cur = cur[k];
+  }
+  cur[keys[keys.length - 1]] = value;
+}
+
+function ensureImport(sourceFile: SourceFile) {
+  const existing = sourceFile.getImportDeclaration('react-i18next');
+  if (!existing) {
+    sourceFile.addImportDeclaration({ moduleSpecifier: 'react-i18next', namedImports: ['useTranslation'] });
+    return;
+  }
+  const hasUse = existing.getNamedImports().some(n => n.getName() === 'useTranslation');
+  if (!hasUse) existing.addNamedImport('useTranslation');
+}
+
+function getTopFunction(node: Node): FunctionLikeDeclaration | undefined {
+  let func = node.getFirstAncestor(f => Node.isFunctionDeclaration(f) || Node.isArrowFunction(f) || Node.isFunctionExpression(f)) as FunctionLikeDeclaration | undefined;
+  if (!func) return undefined;
+  while (true) {
+    const parent = func.getFirstAncestor(f => Node.isFunctionDeclaration(f) || Node.isArrowFunction(f) || Node.isFunctionExpression(f)) as FunctionLikeDeclaration | undefined;
+    if (!parent) break;
+    func = parent;
+  }
+  return func;
+}
+
+function ensureT(sourceFile: SourceFile, node: Node): boolean {
+  const func = getTopFunction(node);
+  if (!func) return false;
+  const body = func.getBody();
+  if (!body || !Node.isBlock(body)) return false;
+  if (processedFuncs.has(func)) return true;
+  const hasT = func.getDescendantsOfKind(SyntaxKind.VariableDeclaration).some(v => {
+    return v.getName() === 't' && v.getInitializer()?.getText().includes('useTranslation');
+  });
+  if (!hasT) {
+    body.insertStatements(0, 'const { t } = useTranslation();');
+    ensureImport(sourceFile);
+  }
+  processedFuncs.add(func);
+  return true;
+}
+
+const ar = JSON.parse(fs.readFileSync(arPath, 'utf8'));
+const en = JSON.parse(fs.readFileSync(enPath, 'utf8'));
+const records: RecordEntry[] = [];
+const fileCounters = new Map<string, number>();
+let processed = 0;
+const processedFuncs = new Set<FunctionLikeDeclaration>();
+
+for (const file of sourceFiles) {
+  if (processed >= LIMIT) break;
+  const rel = path.relative(path.join(__dirname, '../client/src'), file.getFilePath()).replace(/\\/g, '/');
+  const fileBase = path.basename(file.getFilePath(), '.tsx').toLowerCase();
+  let counter = fileCounters.get(fileBase) || 1;
+  const literals = file.getDescendantsOfKind(SyntaxKind.StringLiteral);
+  let modified = false;
+
+  for (const lit of literals) {
+    if (processed >= LIMIT) break;
+    const text = lit.getLiteralText();
+    if (!/[\u0600-\u06FF]/.test(text)) continue;
+    const func = lit.getFirstAncestor(f => Node.isFunctionDeclaration(f) || Node.isArrowFunction(f) || Node.isFunctionExpression(f));
+    if (!func) continue;
+    const key = `auto.${fileBase}.${counter}`;
+    if (!ensureT(file, lit)) continue;
+    const attr = lit.getParentIfKind(SyntaxKind.JsxAttribute);
+    if (attr) {
+      attr.setInitializer(`{t('${key}')}`);
+    } else {
+      lit.replaceWithText(`t('${key}')`);
+    }
+    setNested(ar, ['auto', fileBase, String(counter)], text);
+    setNested(en, ['auto', fileBase, String(counter)], 'TODO(translate)');
+    records.push({ file: rel, original: text });
+    counter++;
+    processed++;
+    modified = true;
+  }
+
+  if (modified) {
+    fileCounters.set(fileBase, counter);
+  }
+}
+
+project.saveSync();
+fs.writeFileSync(arPath, JSON.stringify(ar, null, 2) + '\n');
+fs.writeFileSync(enPath, JSON.stringify(en, null, 2) + '\n');
+
+if (fs.existsSync(csvPath)) {
+  const lines = fs.readFileSync(csvPath, 'utf8').split(/\r?\n/);
+  const header = lines.shift();
+  const filtered = lines.filter(line => {
+    return !records.some(r => line.includes(`"${r.file}"`) && line.includes(`"${r.original.replace(/"/g, '""')}"`));
+  });
+  fs.writeFileSync(csvPath, [header, ...filtered].join('\n'));
+}
+
+console.log(`Processed ${processed} strings`);


### PR DESCRIPTION
## Summary
- add ts-morph/ts-node dev deps
- add script to batch-replace Arabic string literals with autogenerated i18n keys and update locale files

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aad7bd154083258143dba356bafad3