### PR TITLE
chore: enforce Arabic literal scan in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
             exit 1
           fi
 
-      - name: i18n scan
+      - name: Check for Arabic literals
         run: npm run i18n:scan
 
   # 🧪 Testing Suite

--- a/scripts/i18n-scan.mjs
+++ b/scripts/i18n-scan.mjs
@@ -1,13 +1,14 @@
 import fs from "fs";
 import path from "path";
 
-const root = "client/src";
+const root = ".";
 const outDir = path.join("audit", "i18n");
 const hitsFile = path.join(outDir, "hits.json");
 const csvFile = path.join(outDir, "suggested-keys.csv");
 
 const isTS = (f) => /\.(tsx?|jsx?)$/.test(f);
-const ignore = (p) => /(^|\/)(locales|__tests__|__mocks__|fixtures)\//.test(p);
+const ignore = (p) =>
+  /(^|\/)(node_modules|\.git|dist|build|audit|locales|fixtures)\//.test(p);
 const files = [];
 
 (function walk(dir) {


### PR DESCRIPTION
## Summary
- run i18n scan during CI to block Arabic literals
- search entire repo for Arabic characters while ignoring locales and fixtures

## Testing
- `npm run i18n:scan` (fails: Arabic literals found)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aadb3be2ec832599eb6504fe39f902