### PR TITLE
Enable SQLite encryption and add migration checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
         run: npm run type-check
         continue-on-error: false
 
+      - name: Check database migrations
+        run: npm run db:check
+
       - name: Check for dead code
         run: npm run deadcode
         continue-on-error: false

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "drizzle-kit";
 
 export default defineConfig({
-  out: "./migrations",
+  out: "./drizzle/migrations",
   schema: "./shared/schema.ts",
   dialect: "sqlite",
   dbCredentials: {

--- a/drizzle/migrations/0000_nice_vulture.sql
+++ b/drizzle/migrations/0000_nice_vulture.sql
@@ -1,0 +1,311 @@
+CREATE TABLE `companies` (
+	`id` text PRIMARY KEY DEFAULT (hex(randomblob(16))) NOT NULL,
+	`name` text NOT NULL,
+	`commercial_file_number` text,
+	`commercial_file_name` text,
+	`commercial_file_status` integer DEFAULT true NOT NULL,
+	`establishment_date` text,
+	`commercial_registration_number` text,
+	`classification` text,
+	`department` text,
+	`file_type` text,
+	`legal_entity` text,
+	`ownership_category` text,
+	`logo_url` text,
+	`address` text,
+	`phone` text,
+	`email` text,
+	`website` text,
+	`total_employees` integer DEFAULT 0 NOT NULL,
+	`total_licenses` integer DEFAULT 0 NOT NULL,
+	`is_active` integer DEFAULT true NOT NULL,
+	`industry_type` text,
+	`business_activity` text,
+	`location` text,
+	`tax_number` text,
+	`chambers` text,
+	`partnerships` text DEFAULT '[]' NOT NULL,
+	`import_export_license` text,
+	`special_permits` text DEFAULT '[]' NOT NULL,
+	`created_at` integer DEFAULT (unixepoch()) NOT NULL,
+	`updated_at` integer DEFAULT (unixepoch()) NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `IDX_companies_name` ON `companies` (`name`);--> statement-breakpoint
+CREATE INDEX `IDX_companies_commercial_file_number` ON `companies` (`commercial_file_number`);--> statement-breakpoint
+CREATE INDEX `IDX_companies_is_active` ON `companies` (`is_active`);--> statement-breakpoint
+CREATE INDEX `IDX_companies_industry_type` ON `companies` (`industry_type`);--> statement-breakpoint
+CREATE INDEX `IDX_companies_location` ON `companies` (`location`);--> statement-breakpoint
+CREATE INDEX `IDX_companies_created_at` ON `companies` (`created_at`);--> statement-breakpoint
+CREATE TABLE `company_users` (
+	`id` text PRIMARY KEY DEFAULT (hex(randomblob(16))) NOT NULL,
+	`company_id` text NOT NULL,
+	`user_id` text NOT NULL,
+	`role` text DEFAULT 'worker' NOT NULL,
+	`permissions` text DEFAULT '[]' NOT NULL,
+	`created_at` integer DEFAULT (unixepoch()) NOT NULL,
+	`updated_at` integer DEFAULT (unixepoch()) NOT NULL,
+	FOREIGN KEY (`company_id`) REFERENCES `companies`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `IDX_company_users_company_id` ON `company_users` (`company_id`);--> statement-breakpoint
+CREATE INDEX `IDX_company_users_user_id` ON `company_users` (`user_id`);--> statement-breakpoint
+CREATE INDEX `IDX_company_users_role` ON `company_users` (`role`);--> statement-breakpoint
+CREATE INDEX `IDX_company_users_company_user` ON `company_users` (`company_id`,`user_id`);--> statement-breakpoint
+CREATE TABLE `documents` (
+	`id` text PRIMARY KEY DEFAULT (hex(randomblob(16))) NOT NULL,
+	`entity_id` text NOT NULL,
+	`entity_type` text NOT NULL,
+	`name` text NOT NULL,
+	`type` text NOT NULL,
+	`file_name` text NOT NULL,
+	`file_url` text NOT NULL,
+	`file_size` integer,
+	`mime_type` text,
+	`description` text,
+	`tags` text DEFAULT '[]' NOT NULL,
+	`uploaded_by` text NOT NULL,
+	`is_active` integer DEFAULT true NOT NULL,
+	`created_at` integer DEFAULT (unixepoch()) NOT NULL,
+	`updated_at` integer DEFAULT (unixepoch()) NOT NULL,
+	FOREIGN KEY (`uploaded_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `IDX_documents_entity_id` ON `documents` (`entity_id`);--> statement-breakpoint
+CREATE INDEX `IDX_documents_entity_type` ON `documents` (`entity_type`);--> statement-breakpoint
+CREATE INDEX `IDX_documents_type` ON `documents` (`type`);--> statement-breakpoint
+CREATE INDEX `IDX_documents_uploaded_by` ON `documents` (`uploaded_by`);--> statement-breakpoint
+CREATE INDEX `IDX_documents_is_active` ON `documents` (`is_active`);--> statement-breakpoint
+CREATE INDEX `IDX_documents_created_at` ON `documents` (`created_at`);--> statement-breakpoint
+CREATE INDEX `IDX_documents_entity_entity_type` ON `documents` (`entity_id`,`entity_type`);--> statement-breakpoint
+CREATE INDEX `IDX_documents_file_size` ON `documents` (`file_size`);--> statement-breakpoint
+CREATE TABLE `employee_deductions` (
+	`id` text PRIMARY KEY DEFAULT (hex(randomblob(16))) NOT NULL,
+	`employee_id` text NOT NULL,
+	`type` text NOT NULL,
+	`amount` real NOT NULL,
+	`reason` text NOT NULL,
+	`date` text NOT NULL,
+	`status` text DEFAULT 'active' NOT NULL,
+	`processed_by` text NOT NULL,
+	`created_at` integer DEFAULT (unixepoch()) NOT NULL,
+	FOREIGN KEY (`employee_id`) REFERENCES `employees`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`processed_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `IDX_employee_deductions_employee_id` ON `employee_deductions` (`employee_id`);--> statement-breakpoint
+CREATE INDEX `IDX_employee_deductions_type` ON `employee_deductions` (`type`);--> statement-breakpoint
+CREATE INDEX `IDX_employee_deductions_status` ON `employee_deductions` (`status`);--> statement-breakpoint
+CREATE INDEX `IDX_employee_deductions_date` ON `employee_deductions` (`date`);--> statement-breakpoint
+CREATE INDEX `IDX_employee_deductions_processed_by` ON `employee_deductions` (`processed_by`);--> statement-breakpoint
+CREATE INDEX `IDX_employee_deductions_created_at` ON `employee_deductions` (`created_at`);--> statement-breakpoint
+CREATE INDEX `IDX_employee_deductions_employee_type` ON `employee_deductions` (`employee_id`,`type`);--> statement-breakpoint
+CREATE INDEX `IDX_employee_deductions_amount` ON `employee_deductions` (`amount`);--> statement-breakpoint
+CREATE TABLE `employee_leaves` (
+	`id` text PRIMARY KEY DEFAULT (hex(randomblob(16))) NOT NULL,
+	`employee_id` text NOT NULL,
+	`type` text NOT NULL,
+	`status` text DEFAULT 'pending' NOT NULL,
+	`start_date` text NOT NULL,
+	`end_date` text NOT NULL,
+	`days` integer NOT NULL,
+	`reason` text,
+	`approved_by` text,
+	`approved_at` integer,
+	`rejection_reason` text,
+	`created_at` integer DEFAULT (unixepoch()) NOT NULL,
+	`updated_at` integer DEFAULT (unixepoch()) NOT NULL,
+	FOREIGN KEY (`employee_id`) REFERENCES `employees`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`approved_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE INDEX `IDX_employee_leaves_employee_id` ON `employee_leaves` (`employee_id`);--> statement-breakpoint
+CREATE INDEX `IDX_employee_leaves_type` ON `employee_leaves` (`type`);--> statement-breakpoint
+CREATE INDEX `IDX_employee_leaves_status` ON `employee_leaves` (`status`);--> statement-breakpoint
+CREATE INDEX `IDX_employee_leaves_start_date` ON `employee_leaves` (`start_date`);--> statement-breakpoint
+CREATE INDEX `IDX_employee_leaves_end_date` ON `employee_leaves` (`end_date`);--> statement-breakpoint
+CREATE INDEX `IDX_employee_leaves_approved_by` ON `employee_leaves` (`approved_by`);--> statement-breakpoint
+CREATE INDEX `IDX_employee_leaves_created_at` ON `employee_leaves` (`created_at`);--> statement-breakpoint
+CREATE INDEX `IDX_employee_leaves_employee_status` ON `employee_leaves` (`employee_id`,`status`);--> statement-breakpoint
+CREATE INDEX `IDX_employee_leaves_date_range` ON `employee_leaves` (`start_date`,`end_date`);--> statement-breakpoint
+CREATE TABLE `employee_violations` (
+	`id` text PRIMARY KEY DEFAULT (hex(randomblob(16))) NOT NULL,
+	`employee_id` text NOT NULL,
+	`type` text NOT NULL,
+	`description` text NOT NULL,
+	`date` text NOT NULL,
+	`reported_by` text NOT NULL,
+	`severity` text DEFAULT 'medium' NOT NULL,
+	`created_at` integer DEFAULT (unixepoch()) NOT NULL,
+	FOREIGN KEY (`employee_id`) REFERENCES `employees`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`reported_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `IDX_employee_violations_employee_id` ON `employee_violations` (`employee_id`);--> statement-breakpoint
+CREATE INDEX `IDX_employee_violations_type` ON `employee_violations` (`type`);--> statement-breakpoint
+CREATE INDEX `IDX_employee_violations_severity` ON `employee_violations` (`severity`);--> statement-breakpoint
+CREATE INDEX `IDX_employee_violations_date` ON `employee_violations` (`date`);--> statement-breakpoint
+CREATE INDEX `IDX_employee_violations_reported_by` ON `employee_violations` (`reported_by`);--> statement-breakpoint
+CREATE INDEX `IDX_employee_violations_created_at` ON `employee_violations` (`created_at`);--> statement-breakpoint
+CREATE INDEX `IDX_employee_violations_employee_type` ON `employee_violations` (`employee_id`,`type`);--> statement-breakpoint
+CREATE TABLE `employees` (
+	`id` text PRIMARY KEY DEFAULT (hex(randomblob(16))) NOT NULL,
+	`company_id` text NOT NULL,
+	`license_id` text,
+	`first_name` text NOT NULL,
+	`last_name` text NOT NULL,
+	`arabic_name` text,
+	`english_name` text,
+	`passport_number` text,
+	`civil_id` text,
+	`nationality` text,
+	`date_of_birth` text,
+	`gender` text,
+	`marital_status` text,
+	`employee_type` text DEFAULT 'citizen' NOT NULL,
+	`status` text DEFAULT 'active' NOT NULL,
+	`position` text,
+	`department` text,
+	`hire_date` text,
+	`salary` real,
+	`phone` text,
+	`email` text,
+	`address` text,
+	`emergency_contact` text,
+	`emergency_phone` text,
+	`photo_url` text,
+	`documents` text DEFAULT '[]' NOT NULL,
+	`skills` text DEFAULT '[]' NOT NULL,
+	`notes` text,
+	`full_name` text,
+	`job_title` text,
+	`residence_number` text,
+	`residence_expiry` text,
+	`medical_insurance` text,
+	`bank_account` text,
+	`work_permit_start` text,
+	`work_permit_end` text,
+	`is_archived` integer DEFAULT false NOT NULL,
+	`archive_reason` text,
+	`created_at` integer DEFAULT (unixepoch()) NOT NULL,
+	`updated_at` integer DEFAULT (unixepoch()) NOT NULL,
+	FOREIGN KEY (`company_id`) REFERENCES `companies`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`license_id`) REFERENCES `licenses`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE INDEX `IDX_employees_company_id` ON `employees` (`company_id`);--> statement-breakpoint
+CREATE INDEX `IDX_employees_license_id` ON `employees` (`license_id`);--> statement-breakpoint
+CREATE INDEX `IDX_employees_status` ON `employees` (`status`);--> statement-breakpoint
+CREATE INDEX `IDX_employees_employee_type` ON `employees` (`employee_type`);--> statement-breakpoint
+CREATE INDEX `IDX_employees_department` ON `employees` (`department`);--> statement-breakpoint
+CREATE INDEX `IDX_employees_position` ON `employees` (`position`);--> statement-breakpoint
+CREATE INDEX `IDX_employees_civil_id` ON `employees` (`civil_id`);--> statement-breakpoint
+CREATE INDEX `IDX_employees_passport_number` ON `employees` (`passport_number`);--> statement-breakpoint
+CREATE INDEX `IDX_employees_is_archived` ON `employees` (`is_archived`);--> statement-breakpoint
+CREATE INDEX `IDX_employees_hire_date` ON `employees` (`hire_date`);--> statement-breakpoint
+CREATE INDEX `IDX_employees_created_at` ON `employees` (`created_at`);--> statement-breakpoint
+CREATE INDEX `IDX_employees_company_status` ON `employees` (`company_id`,`status`);--> statement-breakpoint
+CREATE TABLE `licenses` (
+	`id` text PRIMARY KEY DEFAULT (hex(randomblob(16))) NOT NULL,
+	`company_id` text NOT NULL,
+	`name` text NOT NULL,
+	`type` text NOT NULL,
+	`number` text NOT NULL,
+	`status` text DEFAULT 'active' NOT NULL,
+	`issue_date` text,
+	`expiry_date` text,
+	`issuing_authority` text,
+	`location` text,
+	`description` text,
+	`documents` text DEFAULT '[]' NOT NULL,
+	`is_active` integer DEFAULT true NOT NULL,
+	`created_at` integer DEFAULT (unixepoch()) NOT NULL,
+	`updated_at` integer DEFAULT (unixepoch()) NOT NULL,
+	FOREIGN KEY (`company_id`) REFERENCES `companies`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `IDX_licenses_company_id` ON `licenses` (`company_id`);--> statement-breakpoint
+CREATE INDEX `IDX_licenses_type` ON `licenses` (`type`);--> statement-breakpoint
+CREATE INDEX `IDX_licenses_status` ON `licenses` (`status`);--> statement-breakpoint
+CREATE INDEX `IDX_licenses_number` ON `licenses` (`number`);--> statement-breakpoint
+CREATE INDEX `IDX_licenses_expiry_date` ON `licenses` (`expiry_date`);--> statement-breakpoint
+CREATE INDEX `IDX_licenses_is_active` ON `licenses` (`is_active`);--> statement-breakpoint
+CREATE INDEX `IDX_licenses_company_status` ON `licenses` (`company_id`,`status`);--> statement-breakpoint
+CREATE INDEX `IDX_licenses_expiry_active` ON `licenses` (`expiry_date`,`is_active`);--> statement-breakpoint
+CREATE TABLE `notifications` (
+	`id` text PRIMARY KEY DEFAULT (hex(randomblob(16))) NOT NULL,
+	`user_id` text NOT NULL,
+	`company_id` text,
+	`type` text NOT NULL,
+	`title` text NOT NULL,
+	`message` text NOT NULL,
+	`data` text DEFAULT '{}' NOT NULL,
+	`is_read` integer DEFAULT false NOT NULL,
+	`created_at` integer DEFAULT (unixepoch()) NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`company_id`) REFERENCES `companies`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `IDX_notifications_user_id` ON `notifications` (`user_id`);--> statement-breakpoint
+CREATE INDEX `IDX_notifications_company_id` ON `notifications` (`company_id`);--> statement-breakpoint
+CREATE INDEX `IDX_notifications_type` ON `notifications` (`type`);--> statement-breakpoint
+CREATE INDEX `IDX_notifications_is_read` ON `notifications` (`is_read`);--> statement-breakpoint
+CREATE INDEX `IDX_notifications_created_at` ON `notifications` (`created_at`);--> statement-breakpoint
+CREATE INDEX `IDX_notifications_user_read` ON `notifications` (`user_id`,`is_read`);--> statement-breakpoint
+CREATE INDEX `IDX_notifications_company_type` ON `notifications` (`company_id`,`type`);--> statement-breakpoint
+CREATE TABLE `refresh_tokens` (
+	`id` text PRIMARY KEY DEFAULT (hex(randomblob(16))) NOT NULL,
+	`user_id` text NOT NULL,
+	`token_hash` text NOT NULL,
+	`family_id` text NOT NULL,
+	`created_at` integer DEFAULT (unixepoch()) NOT NULL,
+	`expires_at` integer NOT NULL,
+	`revoked_at` integer,
+	`replaced_by` text,
+	`user_agent` text,
+	`ip` text,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `IDX_refresh_tokens_user_id` ON `refresh_tokens` (`user_id`);--> statement-breakpoint
+CREATE INDEX `IDX_refresh_tokens_family_id` ON `refresh_tokens` (`family_id`);--> statement-breakpoint
+CREATE INDEX `IDX_refresh_tokens_token_hash` ON `refresh_tokens` (`token_hash`);--> statement-breakpoint
+CREATE TABLE `sessions` (
+	`sid` text PRIMARY KEY NOT NULL,
+	`sess` text NOT NULL,
+	`expire` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `IDX_session_expire` ON `sessions` (`expire`);--> statement-breakpoint
+CREATE INDEX `IDX_session_sid_expire` ON `sessions` (`sid`,`expire`);--> statement-breakpoint
+CREATE TABLE `users` (
+	`id` text PRIMARY KEY DEFAULT (hex(randomblob(16))) NOT NULL,
+	`email` text NOT NULL,
+	`first_name` text NOT NULL,
+	`last_name` text NOT NULL,
+	`password` text NOT NULL,
+	`profile_image_url` text,
+	`role` text DEFAULT 'worker' NOT NULL,
+	`company_id` text,
+	`permissions` text DEFAULT '[]' NOT NULL,
+	`is_active` integer DEFAULT true NOT NULL,
+	`email_verified` integer DEFAULT false NOT NULL,
+	`email_verification_token` text,
+	`email_verification_expires` integer,
+	`password_reset_token` text,
+	`password_reset_expires` integer,
+	`last_password_change` integer,
+	`last_login_at` integer,
+	`sub` text,
+	`claims` text,
+	`created_at` integer DEFAULT (unixepoch()) NOT NULL,
+	`updated_at` integer DEFAULT (unixepoch()) NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `users_email_unique` ON `users` (`email`);--> statement-breakpoint
+CREATE INDEX `IDX_users_email` ON `users` (`email`);--> statement-breakpoint
+CREATE INDEX `IDX_users_company_id` ON `users` (`company_id`);--> statement-breakpoint
+CREATE INDEX `IDX_users_role` ON `users` (`role`);--> statement-breakpoint
+CREATE INDEX `IDX_users_is_active` ON `users` (`is_active`);--> statement-breakpoint
+CREATE INDEX `IDX_users_created_at` ON `users` (`created_at`);

--- a/drizzle/migrations/meta/0000_snapshot.json
+++ b/drizzle/migrations/meta/0000_snapshot.json
@@ -1,0 +1,2242 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "68ca25f5-af2a-4a1c-b844-1d831c51dc6b",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "tables": {
+    "companies": {
+      "name": "companies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(hex(randomblob(16)))"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "commercial_file_number": {
+          "name": "commercial_file_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "commercial_file_name": {
+          "name": "commercial_file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "commercial_file_status": {
+          "name": "commercial_file_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "establishment_date": {
+          "name": "establishment_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "commercial_registration_number": {
+          "name": "commercial_registration_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "classification": {
+          "name": "classification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "department": {
+          "name": "department",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "file_type": {
+          "name": "file_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "legal_entity": {
+          "name": "legal_entity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ownership_category": {
+          "name": "ownership_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_employees": {
+          "name": "total_employees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_licenses": {
+          "name": "total_licenses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "industry_type": {
+          "name": "industry_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "business_activity": {
+          "name": "business_activity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tax_number": {
+          "name": "tax_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "chambers": {
+          "name": "chambers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "partnerships": {
+          "name": "partnerships",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "import_export_license": {
+          "name": "import_export_license",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "special_permits": {
+          "name": "special_permits",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "IDX_companies_name": {
+          "name": "IDX_companies_name",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        },
+        "IDX_companies_commercial_file_number": {
+          "name": "IDX_companies_commercial_file_number",
+          "columns": [
+            "commercial_file_number"
+          ],
+          "isUnique": false
+        },
+        "IDX_companies_is_active": {
+          "name": "IDX_companies_is_active",
+          "columns": [
+            "is_active"
+          ],
+          "isUnique": false
+        },
+        "IDX_companies_industry_type": {
+          "name": "IDX_companies_industry_type",
+          "columns": [
+            "industry_type"
+          ],
+          "isUnique": false
+        },
+        "IDX_companies_location": {
+          "name": "IDX_companies_location",
+          "columns": [
+            "location"
+          ],
+          "isUnique": false
+        },
+        "IDX_companies_created_at": {
+          "name": "IDX_companies_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "company_users": {
+      "name": "company_users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(hex(randomblob(16)))"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'worker'"
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "IDX_company_users_company_id": {
+          "name": "IDX_company_users_company_id",
+          "columns": [
+            "company_id"
+          ],
+          "isUnique": false
+        },
+        "IDX_company_users_user_id": {
+          "name": "IDX_company_users_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "IDX_company_users_role": {
+          "name": "IDX_company_users_role",
+          "columns": [
+            "role"
+          ],
+          "isUnique": false
+        },
+        "IDX_company_users_company_user": {
+          "name": "IDX_company_users_company_user",
+          "columns": [
+            "company_id",
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "company_users_company_id_companies_id_fk": {
+          "name": "company_users_company_id_companies_id_fk",
+          "tableFrom": "company_users",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "company_users_user_id_users_id_fk": {
+          "name": "company_users_user_id_users_id_fk",
+          "tableFrom": "company_users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "documents": {
+      "name": "documents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(hex(randomblob(16)))"
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_url": {
+          "name": "file_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "IDX_documents_entity_id": {
+          "name": "IDX_documents_entity_id",
+          "columns": [
+            "entity_id"
+          ],
+          "isUnique": false
+        },
+        "IDX_documents_entity_type": {
+          "name": "IDX_documents_entity_type",
+          "columns": [
+            "entity_type"
+          ],
+          "isUnique": false
+        },
+        "IDX_documents_type": {
+          "name": "IDX_documents_type",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        },
+        "IDX_documents_uploaded_by": {
+          "name": "IDX_documents_uploaded_by",
+          "columns": [
+            "uploaded_by"
+          ],
+          "isUnique": false
+        },
+        "IDX_documents_is_active": {
+          "name": "IDX_documents_is_active",
+          "columns": [
+            "is_active"
+          ],
+          "isUnique": false
+        },
+        "IDX_documents_created_at": {
+          "name": "IDX_documents_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "IDX_documents_entity_entity_type": {
+          "name": "IDX_documents_entity_entity_type",
+          "columns": [
+            "entity_id",
+            "entity_type"
+          ],
+          "isUnique": false
+        },
+        "IDX_documents_file_size": {
+          "name": "IDX_documents_file_size",
+          "columns": [
+            "file_size"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "documents_uploaded_by_users_id_fk": {
+          "name": "documents_uploaded_by_users_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "employee_deductions": {
+      "name": "employee_deductions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(hex(randomblob(16)))"
+        },
+        "employee_id": {
+          "name": "employee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "processed_by": {
+          "name": "processed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "IDX_employee_deductions_employee_id": {
+          "name": "IDX_employee_deductions_employee_id",
+          "columns": [
+            "employee_id"
+          ],
+          "isUnique": false
+        },
+        "IDX_employee_deductions_type": {
+          "name": "IDX_employee_deductions_type",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        },
+        "IDX_employee_deductions_status": {
+          "name": "IDX_employee_deductions_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "IDX_employee_deductions_date": {
+          "name": "IDX_employee_deductions_date",
+          "columns": [
+            "date"
+          ],
+          "isUnique": false
+        },
+        "IDX_employee_deductions_processed_by": {
+          "name": "IDX_employee_deductions_processed_by",
+          "columns": [
+            "processed_by"
+          ],
+          "isUnique": false
+        },
+        "IDX_employee_deductions_created_at": {
+          "name": "IDX_employee_deductions_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "IDX_employee_deductions_employee_type": {
+          "name": "IDX_employee_deductions_employee_type",
+          "columns": [
+            "employee_id",
+            "type"
+          ],
+          "isUnique": false
+        },
+        "IDX_employee_deductions_amount": {
+          "name": "IDX_employee_deductions_amount",
+          "columns": [
+            "amount"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "employee_deductions_employee_id_employees_id_fk": {
+          "name": "employee_deductions_employee_id_employees_id_fk",
+          "tableFrom": "employee_deductions",
+          "tableTo": "employees",
+          "columnsFrom": [
+            "employee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "employee_deductions_processed_by_users_id_fk": {
+          "name": "employee_deductions_processed_by_users_id_fk",
+          "tableFrom": "employee_deductions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "processed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "employee_leaves": {
+      "name": "employee_leaves",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(hex(randomblob(16)))"
+        },
+        "employee_id": {
+          "name": "employee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "days": {
+          "name": "days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "IDX_employee_leaves_employee_id": {
+          "name": "IDX_employee_leaves_employee_id",
+          "columns": [
+            "employee_id"
+          ],
+          "isUnique": false
+        },
+        "IDX_employee_leaves_type": {
+          "name": "IDX_employee_leaves_type",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        },
+        "IDX_employee_leaves_status": {
+          "name": "IDX_employee_leaves_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "IDX_employee_leaves_start_date": {
+          "name": "IDX_employee_leaves_start_date",
+          "columns": [
+            "start_date"
+          ],
+          "isUnique": false
+        },
+        "IDX_employee_leaves_end_date": {
+          "name": "IDX_employee_leaves_end_date",
+          "columns": [
+            "end_date"
+          ],
+          "isUnique": false
+        },
+        "IDX_employee_leaves_approved_by": {
+          "name": "IDX_employee_leaves_approved_by",
+          "columns": [
+            "approved_by"
+          ],
+          "isUnique": false
+        },
+        "IDX_employee_leaves_created_at": {
+          "name": "IDX_employee_leaves_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "IDX_employee_leaves_employee_status": {
+          "name": "IDX_employee_leaves_employee_status",
+          "columns": [
+            "employee_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "IDX_employee_leaves_date_range": {
+          "name": "IDX_employee_leaves_date_range",
+          "columns": [
+            "start_date",
+            "end_date"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "employee_leaves_employee_id_employees_id_fk": {
+          "name": "employee_leaves_employee_id_employees_id_fk",
+          "tableFrom": "employee_leaves",
+          "tableTo": "employees",
+          "columnsFrom": [
+            "employee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "employee_leaves_approved_by_users_id_fk": {
+          "name": "employee_leaves_approved_by_users_id_fk",
+          "tableFrom": "employee_leaves",
+          "tableTo": "users",
+          "columnsFrom": [
+            "approved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "employee_violations": {
+      "name": "employee_violations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(hex(randomblob(16)))"
+        },
+        "employee_id": {
+          "name": "employee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reported_by": {
+          "name": "reported_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'medium'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "IDX_employee_violations_employee_id": {
+          "name": "IDX_employee_violations_employee_id",
+          "columns": [
+            "employee_id"
+          ],
+          "isUnique": false
+        },
+        "IDX_employee_violations_type": {
+          "name": "IDX_employee_violations_type",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        },
+        "IDX_employee_violations_severity": {
+          "name": "IDX_employee_violations_severity",
+          "columns": [
+            "severity"
+          ],
+          "isUnique": false
+        },
+        "IDX_employee_violations_date": {
+          "name": "IDX_employee_violations_date",
+          "columns": [
+            "date"
+          ],
+          "isUnique": false
+        },
+        "IDX_employee_violations_reported_by": {
+          "name": "IDX_employee_violations_reported_by",
+          "columns": [
+            "reported_by"
+          ],
+          "isUnique": false
+        },
+        "IDX_employee_violations_created_at": {
+          "name": "IDX_employee_violations_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "IDX_employee_violations_employee_type": {
+          "name": "IDX_employee_violations_employee_type",
+          "columns": [
+            "employee_id",
+            "type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "employee_violations_employee_id_employees_id_fk": {
+          "name": "employee_violations_employee_id_employees_id_fk",
+          "tableFrom": "employee_violations",
+          "tableTo": "employees",
+          "columnsFrom": [
+            "employee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "employee_violations_reported_by_users_id_fk": {
+          "name": "employee_violations_reported_by_users_id_fk",
+          "tableFrom": "employee_violations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reported_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "employees": {
+      "name": "employees",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(hex(randomblob(16)))"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "license_id": {
+          "name": "license_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "arabic_name": {
+          "name": "arabic_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "english_name": {
+          "name": "english_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "passport_number": {
+          "name": "passport_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "civil_id": {
+          "name": "civil_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "nationality": {
+          "name": "nationality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gender": {
+          "name": "gender",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "marital_status": {
+          "name": "marital_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "employee_type": {
+          "name": "employee_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'citizen'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "department": {
+          "name": "department",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hire_date": {
+          "name": "hire_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "salary": {
+          "name": "salary",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "emergency_contact": {
+          "name": "emergency_contact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "emergency_phone": {
+          "name": "emergency_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "documents": {
+          "name": "documents",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "skills": {
+          "name": "skills",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "job_title": {
+          "name": "job_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "residence_number": {
+          "name": "residence_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "residence_expiry": {
+          "name": "residence_expiry",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "medical_insurance": {
+          "name": "medical_insurance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bank_account": {
+          "name": "bank_account",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "work_permit_start": {
+          "name": "work_permit_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "work_permit_end": {
+          "name": "work_permit_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "archive_reason": {
+          "name": "archive_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "IDX_employees_company_id": {
+          "name": "IDX_employees_company_id",
+          "columns": [
+            "company_id"
+          ],
+          "isUnique": false
+        },
+        "IDX_employees_license_id": {
+          "name": "IDX_employees_license_id",
+          "columns": [
+            "license_id"
+          ],
+          "isUnique": false
+        },
+        "IDX_employees_status": {
+          "name": "IDX_employees_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "IDX_employees_employee_type": {
+          "name": "IDX_employees_employee_type",
+          "columns": [
+            "employee_type"
+          ],
+          "isUnique": false
+        },
+        "IDX_employees_department": {
+          "name": "IDX_employees_department",
+          "columns": [
+            "department"
+          ],
+          "isUnique": false
+        },
+        "IDX_employees_position": {
+          "name": "IDX_employees_position",
+          "columns": [
+            "position"
+          ],
+          "isUnique": false
+        },
+        "IDX_employees_civil_id": {
+          "name": "IDX_employees_civil_id",
+          "columns": [
+            "civil_id"
+          ],
+          "isUnique": false
+        },
+        "IDX_employees_passport_number": {
+          "name": "IDX_employees_passport_number",
+          "columns": [
+            "passport_number"
+          ],
+          "isUnique": false
+        },
+        "IDX_employees_is_archived": {
+          "name": "IDX_employees_is_archived",
+          "columns": [
+            "is_archived"
+          ],
+          "isUnique": false
+        },
+        "IDX_employees_hire_date": {
+          "name": "IDX_employees_hire_date",
+          "columns": [
+            "hire_date"
+          ],
+          "isUnique": false
+        },
+        "IDX_employees_created_at": {
+          "name": "IDX_employees_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "IDX_employees_company_status": {
+          "name": "IDX_employees_company_status",
+          "columns": [
+            "company_id",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "employees_company_id_companies_id_fk": {
+          "name": "employees_company_id_companies_id_fk",
+          "tableFrom": "employees",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "employees_license_id_licenses_id_fk": {
+          "name": "employees_license_id_licenses_id_fk",
+          "tableFrom": "employees",
+          "tableTo": "licenses",
+          "columnsFrom": [
+            "license_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "licenses": {
+      "name": "licenses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(hex(randomblob(16)))"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "number": {
+          "name": "number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "issue_date": {
+          "name": "issue_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expiry_date": {
+          "name": "expiry_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "issuing_authority": {
+          "name": "issuing_authority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "documents": {
+          "name": "documents",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "IDX_licenses_company_id": {
+          "name": "IDX_licenses_company_id",
+          "columns": [
+            "company_id"
+          ],
+          "isUnique": false
+        },
+        "IDX_licenses_type": {
+          "name": "IDX_licenses_type",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        },
+        "IDX_licenses_status": {
+          "name": "IDX_licenses_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "IDX_licenses_number": {
+          "name": "IDX_licenses_number",
+          "columns": [
+            "number"
+          ],
+          "isUnique": false
+        },
+        "IDX_licenses_expiry_date": {
+          "name": "IDX_licenses_expiry_date",
+          "columns": [
+            "expiry_date"
+          ],
+          "isUnique": false
+        },
+        "IDX_licenses_is_active": {
+          "name": "IDX_licenses_is_active",
+          "columns": [
+            "is_active"
+          ],
+          "isUnique": false
+        },
+        "IDX_licenses_company_status": {
+          "name": "IDX_licenses_company_status",
+          "columns": [
+            "company_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "IDX_licenses_expiry_active": {
+          "name": "IDX_licenses_expiry_active",
+          "columns": [
+            "expiry_date",
+            "is_active"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "licenses_company_id_companies_id_fk": {
+          "name": "licenses_company_id_companies_id_fk",
+          "tableFrom": "licenses",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notifications": {
+      "name": "notifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(hex(randomblob(16)))"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "IDX_notifications_user_id": {
+          "name": "IDX_notifications_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "IDX_notifications_company_id": {
+          "name": "IDX_notifications_company_id",
+          "columns": [
+            "company_id"
+          ],
+          "isUnique": false
+        },
+        "IDX_notifications_type": {
+          "name": "IDX_notifications_type",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        },
+        "IDX_notifications_is_read": {
+          "name": "IDX_notifications_is_read",
+          "columns": [
+            "is_read"
+          ],
+          "isUnique": false
+        },
+        "IDX_notifications_created_at": {
+          "name": "IDX_notifications_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "IDX_notifications_user_read": {
+          "name": "IDX_notifications_user_read",
+          "columns": [
+            "user_id",
+            "is_read"
+          ],
+          "isUnique": false
+        },
+        "IDX_notifications_company_type": {
+          "name": "IDX_notifications_company_type",
+          "columns": [
+            "company_id",
+            "type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_company_id_companies_id_fk": {
+          "name": "notifications_company_id_companies_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "refresh_tokens": {
+      "name": "refresh_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(hex(randomblob(16)))"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "family_id": {
+          "name": "family_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "replaced_by": {
+          "name": "replaced_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "IDX_refresh_tokens_user_id": {
+          "name": "IDX_refresh_tokens_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "IDX_refresh_tokens_family_id": {
+          "name": "IDX_refresh_tokens_family_id",
+          "columns": [
+            "family_id"
+          ],
+          "isUnique": false
+        },
+        "IDX_refresh_tokens_token_hash": {
+          "name": "IDX_refresh_tokens_token_hash",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "sid": {
+          "name": "sid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sess": {
+          "name": "sess",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expire": {
+          "name": "expire",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "IDX_session_expire": {
+          "name": "IDX_session_expire",
+          "columns": [
+            "expire"
+          ],
+          "isUnique": false
+        },
+        "IDX_session_sid_expire": {
+          "name": "IDX_session_sid_expire",
+          "columns": [
+            "sid",
+            "expire"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(hex(randomblob(16)))"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "profile_image_url": {
+          "name": "profile_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'worker'"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "email_verification_token": {
+          "name": "email_verification_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email_verification_expires": {
+          "name": "email_verification_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password_reset_token": {
+          "name": "password_reset_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password_reset_expires": {
+          "name": "password_reset_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_password_change": {
+          "name": "last_password_change",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sub": {
+          "name": "sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "claims": {
+          "name": "claims",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "IDX_users_email": {
+          "name": "IDX_users_email",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "IDX_users_company_id": {
+          "name": "IDX_users_company_id",
+          "columns": [
+            "company_id"
+          ],
+          "isUnique": false
+        },
+        "IDX_users_role": {
+          "name": "IDX_users_role",
+          "columns": [
+            "role"
+          ],
+          "isUnique": false
+        },
+        "IDX_users_is_active": {
+          "name": "IDX_users_is_active",
+          "columns": [
+            "is_active"
+          ],
+          "isUnique": false
+        },
+        "IDX_users_created_at": {
+          "name": "IDX_users_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "6",
+      "when": 1756036203978,
+      "tag": "0000_nice_vulture",
+      "breakpoints": true
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "dist:electron": "npm run build:electron && cd electron && npm run dist",
     "check": "tsc",
     "db:push": "drizzle-kit push",
+    "db:check": "drizzle-kit check",
     "clean": "rimraf dist node_modules/.cache",
     "clean:electron": "rimraf electron/dist electron/dist-electron",
     "lint": "npx -y eslint@8 . --ext .ts,.tsx --max-warnings=0 --config .eslintrc.cjs",

--- a/server/index.ts
+++ b/server/index.ts
@@ -47,6 +47,13 @@ export const app = express();
 const PORT = env.PORT;
 const vitalsRateLimiter = createRateLimiter('general');
 
+if (
+  env.NODE_ENV === 'production' &&
+  (!process.env.DB_ENCRYPTION_KEY || process.env.DB_ENCRYPTION_KEY.length < 32)
+) {
+  throw new Error('DB_ENCRYPTION_KEY is required and must be at least 32 characters');
+}
+
 // Trust proxy for rate limiting
 app.set('trust proxy', 1);
 

--- a/server/models/db.ts
+++ b/server/models/db.ts
@@ -1,9 +1,7 @@
-import { drizzle } from 'drizzle-orm/better-sqlite3';
-import Database from 'better-sqlite3';
-import * as schema from '@shared/schema';
+import { secureDbManager } from '../utils/dbSecurity';
 import { env } from '../utils/env';
 
-const dbPath = env.DATABASE_URL || 'dev.db';
-const sqlite = new Database(dbPath);
+await secureDbManager.initializeDatabase(env.DATABASE_URL);
 
-export const db = drizzle(sqlite, { schema });
+export const db = secureDbManager.getDatabase();
+export const sqlite = secureDbManager.getRawDatabase();


### PR DESCRIPTION
## Summary
- Ensure production startup fails without strong `DB_ENCRYPTION_KEY`
- Use secure database manager so SQLite runs with SQLCipher encryption
- Configure Drizzle migrations to `drizzle/migrations` and commit initial migration
- Add `db:check` script and CI step to verify migrations

## Testing
- `npx drizzle-kit generate`
- `DATABASE_URL=./temp.db npx drizzle-kit migrate`
- `npm run db:check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aafb8fa61c832583ef4d0105f35467