### PR TITLE
feat: add CSP nonce middleware with tests

### DIFF
--- a/tests/csp-nonce.test.ts
+++ b/tests/csp-nonce.test.ts
@@ -16,17 +16,17 @@ describe('CSP Nonce Implementation Tests', () => {
     it('should generate unique nonces for each request', async () => {
       const response1 = await request(app).get('/health');
       const response2 = await request(app).get('/health');
-      
+
       expect(response1.headers).toHaveProperty('content-security-policy');
       expect(response2.headers).toHaveProperty('content-security-policy');
-      
+
       const csp1 = response1.headers['content-security-policy'];
       const csp2 = response2.headers['content-security-policy'];
-      
+
       // Extract nonces from CSP headers
-      const nonce1 = csp1.match(/'nonce-([A-Za-z0-9+/]{22}==)'/)?.[1];
-      const nonce2 = csp2.match(/'nonce-([A-Za-z0-9+/]{22}==)'/)?.[1];
-      
+      const nonce1 = csp1.match(/'nonce-([^']+)'/)?.[1];
+      const nonce2 = csp2.match(/'nonce-([^']+)'/)?.[1];
+
       expect(nonce1).toBeDefined();
       expect(nonce2).toBeDefined();
       expect(nonce1).not.toBe(nonce2); // Nonces should be unique
@@ -35,11 +35,11 @@ describe('CSP Nonce Implementation Tests', () => {
     it('should validate nonce format', async () => {
       const response = await request(app).get('/health');
       const csp = response.headers['content-security-policy'];
-      
-      const nonce = csp.match(/'nonce-([A-Za-z0-9+/]{22}==)'/)?.[1];
-      
+
+      const nonce = csp.match(/'nonce-([^']+)'/)?.[1];
+
       expect(nonce).toBeDefined();
-      expect(nonce).toMatch(/^[A-Za-z0-9+/]{22}==$/);
+      expect(nonce).toMatch(/^[A-Za-z0-9_-]+$/);
     });
   });
 
@@ -47,7 +47,7 @@ describe('CSP Nonce Implementation Tests', () => {
     it('should have correct CSP directives without unsafe options', async () => {
       const response = await request(app).get('/health');
       const csp = response.headers['content-security-policy'];
-      
+
       // Required directives
       expect(csp).toContain("default-src 'self'");
       expect(csp).toContain("script-src 'self'");
@@ -57,7 +57,7 @@ describe('CSP Nonce Implementation Tests', () => {
       expect(csp).toContain("frame-src 'none'");
       expect(csp).toContain("object-src 'none'");
       expect(csp).toContain("base-uri 'self'");
-      
+
       // Should NOT contain unsafe directives
       expect(csp).not.toContain("'unsafe-inline'");
       expect(csp).not.toContain("'unsafe-eval'");
@@ -66,27 +66,27 @@ describe('CSP Nonce Implementation Tests', () => {
     it('should have nonce-based script-src directive', async () => {
       const response = await request(app).get('/health');
       const csp = response.headers['content-security-policy'];
-      
+
       // Should contain nonce in script-src
-      expect(csp).toMatch(/script-src 'self' 'nonce-[A-Za-z0-9+/]{22}=='/);
+      expect(csp).toMatch(/script-src[^;]*'nonce-[^']+'/);
     });
   });
 
   describe('CSP Header Consistency', () => {
     it('should maintain consistent CSP across different endpoints', async () => {
       const endpoints = ['/health', '/api/csrf-token'];
-      
+
       for (const endpoint of endpoints) {
         const response = await request(app).get(endpoint);
         const csp = response.headers['content-security-policy'];
-        
+
         // All endpoints should have CSP
         expect(csp).toBeDefined();
-        
+
         // Should not contain unsafe directives
         expect(csp).not.toContain("'unsafe-inline'");
         expect(csp).not.toContain("'unsafe-eval'");
-        
+
         // Should contain required directives
         expect(csp).toContain("default-src 'self'");
         expect(csp).toContain("frame-src 'none'");
@@ -98,20 +98,20 @@ describe('CSP Nonce Implementation Tests', () => {
   describe('Security Headers Integration', () => {
     it('should have all required security headers', async () => {
       const response = await request(app).get('/health');
-      
+
       // Required security headers
       expect(response.headers).toHaveProperty('x-content-type-options');
       expect(response.headers['x-content-type-options']).toBe('nosniff');
-      
+
       expect(response.headers).toHaveProperty('x-frame-options');
       expect(response.headers['x-frame-options']).toBe('DENY');
-      
+
       expect(response.headers).toHaveProperty('x-xss-protection');
       expect(response.headers['x-xss-protection']).toBe('1; mode=block');
-      
+
       expect(response.headers).toHaveProperty('referrer-policy');
       expect(response.headers['referrer-policy']).toBe('strict-origin-when-cross-origin');
-      
+
       // CSP header
       expect(response.headers).toHaveProperty('content-security-policy');
     });
@@ -122,13 +122,13 @@ describe('CSP Nonce Implementation Tests', () => {
       // This test would require access to response.locals
       // In a real implementation, you might want to expose this via an endpoint
       const response = await request(app).get('/health');
-      
+
       // The nonce should be available in the CSP header
       const csp = response.headers['content-security-policy'];
-      const nonce = csp.match(/'nonce-([A-Za-z0-9+/]{22}==)'/)?.[1];
-      
+      const nonce = csp.match(/'nonce-([^']+)'/)?.[1];
+
       expect(nonce).toBeDefined();
-      expect(nonce).toMatch(/^[A-Za-z0-9+/]{22}==$/);
+      expect(nonce).toMatch(/^[A-Za-z0-9_-]+$/);
     });
   });
 });
@@ -139,18 +139,18 @@ describe('CSP Violation Prevention', () => {
     // In a real browser, inline scripts without nonce would be blocked
     const response = await request(app).get('/health');
     const csp = response.headers['content-security-policy'];
-    
+
     // Should not allow unsafe-inline
     expect(csp).not.toContain("'unsafe-inline'");
-    
+
     // Should require nonce for inline scripts
-    expect(csp).toMatch(/script-src 'self' 'nonce-[A-Za-z0-9+/]{22}=='/);
+    expect(csp).toMatch(/script-src[^;]*'nonce-[^']+'/);
   });
 
   it('should prevent eval() execution', async () => {
     const response = await request(app).get('/health');
     const csp = response.headers['content-security-policy'];
-    
+
     // Should not allow unsafe-eval
     expect(csp).not.toContain("'unsafe-eval'");
   });

--- a/tests/csp-simple.test.ts
+++ b/tests/csp-simple.test.ts
@@ -12,7 +12,7 @@ import { cspUtils } from '../server/middleware/security';
 
 // Define generateNonce function locally for testing
 function generateNonce(): string {
-  return crypto.randomBytes(16).toString('base64');
+  return crypto.randomBytes(16).toString('base64url');
 }
 
 describe('CSP Nonce Implementation Tests', () => {
@@ -20,7 +20,7 @@ describe('CSP Nonce Implementation Tests', () => {
     it('should generate unique nonces', () => {
       const nonce1 = generateNonce();
       const nonce2 = generateNonce();
-      
+
       expect(nonce1).toBeDefined();
       expect(nonce2).toBeDefined();
       expect(nonce1).not.toBe(nonce2);
@@ -28,16 +28,15 @@ describe('CSP Nonce Implementation Tests', () => {
 
     it('should generate nonces in correct format', () => {
       const nonce = generateNonce();
-      
-      // Should be base64 encoded and 22 characters (16 bytes)
-      expect(nonce).toMatch(/^[A-Za-z0-9+/]{22}==$/);
-      expect(nonce.length).toBe(24); // 22 chars + 2 padding
+
+      // Should be URL-safe base64 encoded
+      expect(nonce).toMatch(/^[A-Za-z0-9_-]+$/);
     });
 
     it('should validate nonce format correctly', () => {
-      const validNonce = 'a1b2c3d4e5f6g7h8i9j0k1==';
-      const invalidNonce = 'invalid-nonce';
-      
+      const validNonce = 'a1b2c3d4e5f6g7h8i9j0k1';
+      const invalidNonce = 'invalid nonce!*';
+
       expect(cspUtils.validateNonce(validNonce)).toBe(true);
       expect(cspUtils.validateNonce(invalidNonce)).toBe(false);
     });
@@ -45,30 +44,30 @@ describe('CSP Nonce Implementation Tests', () => {
 
   describe('CSP Utils', () => {
     it('should generate script tags with nonce', () => {
-      const mockReq = { cspNonce: 'a1b2c3d4e5f6g7h8i9j0k1==' } as any;
+      const mockReq = { cspNonce: 'a1b2c3d4e5f6g7h8i9j0k1' } as any;
       const scriptContent = 'console.log("test");';
-      
+
       const scriptTag = cspUtils.scriptTag(mockReq, scriptContent);
-      
-      expect(scriptTag).toContain('nonce="a1b2c3d4e5f6g7h8i9j0k1=="');
+
+      expect(scriptTag).toContain('nonce="a1b2c3d4e5f6g7h8i9j0k1"');
       expect(scriptTag).toContain(scriptContent);
       expect(scriptTag).toMatch(/<script nonce="[^"]+">.*<\/script>/);
     });
 
     it('should generate style tags with nonce', () => {
-      const mockReq = { cspNonce: 'a1b2c3d4e5f6g7h8i9j0k1==' } as any;
+      const mockReq = { cspNonce: 'a1b2c3d4e5f6g7h8i9j0k1' } as any;
       const styleContent = 'body { color: red; }';
-      
+
       const styleTag = cspUtils.styleTag(mockReq, styleContent);
-      
-      expect(styleTag).toContain('nonce="a1b2c3d4e5f6g7h8i9j0k1=="');
+
+      expect(styleTag).toContain('nonce="a1b2c3d4e5f6g7h8i9j0k1"');
       expect(styleTag).toContain(styleContent);
       expect(styleTag).toMatch(/<style nonce="[^"]+">.*<\/style>/);
     });
 
     it('should handle missing nonce gracefully', () => {
       const mockReq = {} as any;
-      
+
       expect(cspUtils.getNonce(mockReq)).toBe('');
       expect(cspUtils.scriptTag(mockReq, 'test')).toContain('nonce=""');
       expect(cspUtils.styleTag(mockReq, 'test')).toContain('nonce=""');
@@ -77,34 +76,17 @@ describe('CSP Nonce Implementation Tests', () => {
 
   describe('CSP Directive Validation', () => {
     it('should create correct CSP directives', () => {
-      const nonce = 'a1b2c3d4e5f6g7h8i9j0k1==';
-      
+      const nonce = 'a1b2c3d4e5f6g7h8i9j0k1';
+
       const cspDirectives = {
         defaultSrc: ["'self'"],
-        scriptSrc: [
-          "'self'",
-          `'nonce-${nonce}'`
-        ],
-        styleSrc: [
-          "'self'"
-        ],
-        imgSrc: [
-          "'self'",
-          "data:",
-          "https:"
-        ],
-        connectSrc: [
-          "'self'"
-        ],
-        frameSrc: [
-          "'none'"
-        ],
-        objectSrc: [
-          "'none'"
-        ],
-        baseUri: [
-          "'self'"
-        ]
+        scriptSrc: ["'self'", `'nonce-${nonce}'`],
+        styleSrc: ["'self'"],
+        imgSrc: ["'self'", 'data:', 'https:'],
+        connectSrc: ["'self'"],
+        frameSrc: ["'none'"],
+        objectSrc: ["'none'"],
+        baseUri: ["'self'"],
       };
 
       // Verify all required directives are present
@@ -113,8 +95,8 @@ describe('CSP Nonce Implementation Tests', () => {
       expect(cspDirectives.scriptSrc).toContain(`'nonce-${nonce}'`);
       expect(cspDirectives.styleSrc).toContain("'self'");
       expect(cspDirectives.imgSrc).toContain("'self'");
-      expect(cspDirectives.imgSrc).toContain("data:");
-      expect(cspDirectives.imgSrc).toContain("https:");
+      expect(cspDirectives.imgSrc).toContain('data:');
+      expect(cspDirectives.imgSrc).toContain('https:');
       expect(cspDirectives.connectSrc).toContain("'self'");
       expect(cspDirectives.frameSrc).toContain("'none'");
       expect(cspDirectives.objectSrc).toContain("'none'");

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -5,6 +5,7 @@
  * @version 1.0.0
  */
 
+import './test-env.js';
 import request from 'supertest';
 import { app } from '../server/index';
 
@@ -12,26 +13,26 @@ describe('Server Security Tests', () => {
   describe('Helmet Security Headers', () => {
     it('should include security headers', async () => {
       const response = await request(app).get('/health');
-      
+
       expect(response.headers).toHaveProperty('x-content-type-options');
       expect(response.headers['x-content-type-options']).toBe('nosniff');
-      
+
       expect(response.headers).toHaveProperty('x-frame-options');
       expect(response.headers['x-frame-options']).toBe('DENY');
-      
+
       expect(response.headers).toHaveProperty('x-xss-protection');
       expect(response.headers['x-xss-protection']).toBe('1; mode=block');
-      
+
       expect(response.headers).toHaveProperty('referrer-policy');
       expect(response.headers['referrer-policy']).toBe('strict-origin-when-cross-origin');
     });
 
     it('should have Content Security Policy header', async () => {
       const response = await request(app).get('/health');
-      
+
       expect(response.headers).toHaveProperty('content-security-policy');
       const csp = response.headers['content-security-policy'];
-      
+
       expect(csp).toContain("default-src 'self'");
       expect(csp).toContain("frame-src 'none'");
       expect(csp).toContain("object-src 'none'");
@@ -39,17 +40,17 @@ describe('Server Security Tests', () => {
 
     it('should have nonce-based CSP without unsafe directives', async () => {
       const response = await request(app).get('/health');
-      
+
       expect(response.headers).toHaveProperty('content-security-policy');
       const csp = response.headers['content-security-policy'];
-      
+
       // Should contain nonce-based script-src
-      expect(csp).toMatch(/script-src 'self' 'nonce-[A-Za-z0-9+/]{22}=='/);
-      
+      expect(csp).toMatch(/script-src[^;]*'nonce-[^']+'/);
+
       // Should NOT contain unsafe directives
       expect(csp).not.toContain("'unsafe-inline'");
       expect(csp).not.toContain("'unsafe-eval'");
-      
+
       // Should contain required directives
       expect(csp).toContain("default-src 'self'");
       expect(csp).toContain("style-src 'self'");
@@ -74,13 +75,13 @@ describe('Server Security Tests', () => {
       // This test might be flaky in development due to skip conditions
       // In production, it would block after exceeding the limit
       const responses = await Promise.all(
-        Array(150).fill(0).map(() => 
-          request(app).get('/api/test-endpoint')
-        )
+        Array(150)
+          .fill(0)
+          .map(() => request(app).get('/api/test-endpoint')),
       );
-      
+
       // At least some requests should be blocked (429 status)
-      const blockedRequests = responses.filter(r => r.status === 429);
+      const blockedRequests = responses.filter((r) => r.status === 429);
       expect(blockedRequests.length).toBeGreaterThan(0);
     });
   });
@@ -88,7 +89,7 @@ describe('Server Security Tests', () => {
   describe('CSRF Protection', () => {
     it('should provide CSRF token endpoint', async () => {
       const response = await request(app).get('/api/csrf-token');
-      
+
       expect(response.status).toBe(200);
       expect(response.body).toHaveProperty('csrfToken');
       expect(response.body).toHaveProperty('message');
@@ -97,15 +98,13 @@ describe('Server Security Tests', () => {
 
     it('should include CSRF token in headers', async () => {
       const response = await request(app).get('/api/csrf-token');
-      
+
       expect(response.headers).toHaveProperty('x-csrf-token');
       expect(response.headers['x-csrf-token']).toBeTruthy();
     });
 
     it('should reject requests without CSRF token', async () => {
-      const response = await request(app)
-        .post('/api/test-endpoint')
-        .send({ data: 'test' });
+      const response = await request(app).post('/api/test-endpoint').send({ data: 'test' });
 
       // Should be blocked by CSRF protection
       expect(response.status).toBe(403);
@@ -138,43 +137,43 @@ describe('Server Security Tests', () => {
   describe('Input Validation', () => {
     it('should sanitize XSS attempts', async () => {
       const xssPayload = '<script>alert("xss")</script>';
-      
+
       const response = await request(app)
         .post('/api/test-endpoint')
         .set('X-CSRF-Token', 'valid-token')
-        .send({ 
+        .send({
           data: xssPayload,
           query: 'javascript:alert("xss")',
-          body: 'onload=alert("xss")'
+          body: 'onload=alert("xss")',
         });
-      
+
       // The request should be processed (sanitized) or blocked
       expect([200, 400, 403]).toContain(response.status);
     });
 
     it('should sanitize SQL injection attempts', async () => {
       const sqlPayload = "'; DROP TABLE users; --";
-      
+
       const response = await request(app)
         .post('/api/test-endpoint')
         .set('X-CSRF-Token', 'valid-token')
-        .send({ 
+        .send({
           query: sqlPayload,
-          data: "UNION SELECT * FROM users"
+          data: 'UNION SELECT * FROM users',
         });
-      
+
       // Should be blocked or sanitized
       expect([200, 400, 403]).toContain(response.status);
     });
 
     it('should limit input size', async () => {
       const largePayload = 'x'.repeat(15000); // Exceeds 10,000 limit
-      
+
       const response = await request(app)
         .post('/api/test-endpoint')
         .set('X-CSRF-Token', 'valid-token')
         .send({ data: largePayload });
-      
+
       // Should be blocked due to size limit
       expect([400, 413]).toContain(response.status);
     });
@@ -185,7 +184,7 @@ describe('Server Security Tests', () => {
       // This would require mocking the IP blocking middleware
       // In a real test, you'd need to simulate suspicious activity
       const response = await request(app).get('/health');
-      
+
       // Normal requests should pass
       expect(response.status).toBe(200);
     });
@@ -194,12 +193,12 @@ describe('Server Security Tests', () => {
   describe('File Upload Security', () => {
     it('should reject oversized files', async () => {
       const largeBuffer = Buffer.alloc(11 * 1024 * 1024); // 11MB
-      
+
       const response = await request(app)
         .post('/api/upload')
         .set('X-CSRF-Token', 'valid-token')
         .attach('file', largeBuffer, 'test.pdf');
-      
+
       expect(response.status).toBe(413);
     });
 
@@ -208,7 +207,7 @@ describe('Server Security Tests', () => {
         .post('/api/upload')
         .set('X-CSRF-Token', 'valid-token')
         .attach('file', Buffer.from('test'), 'test.php');
-      
+
       expect(response.status).toBe(400);
     });
 
@@ -217,7 +216,7 @@ describe('Server Security Tests', () => {
         .post('/api/upload')
         .set('X-CSRF-Token', 'valid-token')
         .attach('file', Buffer.from('test'), '../../../etc/passwd');
-      
+
       expect(response.status).toBe(400);
     });
   });
@@ -227,16 +226,14 @@ describe('Server Security Tests', () => {
       // This would require setting NODE_ENV=production
       // In development, it might show more details
       const response = await request(app).get('/nonexistent-endpoint');
-      
+
       expect(response.status).toBe(404);
       expect(response.body).toHaveProperty('message');
     });
 
     it('should handle CSRF errors gracefully', async () => {
-      const response = await request(app)
-        .post('/api/test-endpoint')
-        .send({ data: 'test' });
-      
+      const response = await request(app).post('/api/test-endpoint').send({ data: 'test' });
+
       expect(response.status).toBe(403);
       expect(response.body).toHaveProperty('error');
       expect(response.body).toHaveProperty('message');
@@ -246,7 +243,7 @@ describe('Server Security Tests', () => {
   describe('Health Check Security', () => {
     it('should return security status', async () => {
       const response = await request(app).get('/health');
-      
+
       expect(response.status).toBe(200);
       expect(response.body).toHaveProperty('security');
       expect(response.body.security).toHaveProperty('helmet');
@@ -254,7 +251,7 @@ describe('Server Security Tests', () => {
       expect(response.body.security).toHaveProperty('csrf');
       expect(response.body.security).toHaveProperty('inputValidation');
       expect(response.body.security).toHaveProperty('ipBlocking');
-      
+
       // All security measures should be enabled
       expect(response.body.security.helmet).toBe(true);
       expect(response.body.security.rateLimit).toBe(true);
@@ -268,12 +265,12 @@ describe('Server Security Tests', () => {
 describe('Security Middleware Integration', () => {
   it('should apply all security middleware in correct order', async () => {
     const response = await request(app).get('/health');
-    
+
     // Should have all security headers
     expect(response.headers).toHaveProperty('x-content-type-options');
     expect(response.headers).toHaveProperty('x-frame-options');
     expect(response.headers).toHaveProperty('x-xss-protection');
-    
+
     // Should return successful response
     expect(response.status).toBe(200);
     expect(response.body).toHaveProperty('status', 'OK');


### PR DESCRIPTION
## Summary
- add middleware generating nonce and manual CSP header
- expose nonce via `res.locals.nonce`
- update tests for URL-safe nonces and header pattern

## Testing
- `npx vitest run --config tests/vitest.config.ts tests/csp-nonce.test.ts tests/csp-simple.test.ts tests/security.test.ts` *(fails: address in use / missing services)*

------
https://chatgpt.com/codex/tasks/task_e_68ab077eb16483259aebdecd26ac06e7