### PR TITLE
Add Playwright accessibility smoke tests

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "client",
       "dependencies": {
         "@alloc/quick-lru": "5.2.0",
         "@tanstack/react-query": "5.60.5",
@@ -23,6 +22,7 @@
         "@axe-core/playwright": "4.10.2",
         "@axe-core/react": "4.10.2",
         "@lhci/cli": "0.14.0",
+        "@playwright/test": "^1.55.0",
         "@testing-library/jest-dom": "6.4.8",
         "@testing-library/react": "14.2.1",
         "@testing-library/user-event": "14.5.2",
@@ -1029,6 +1029,22 @@
       "resolved": "https://registry.npmjs.org/@paulirish/trace_engine/-/trace_engine-0.0.23.tgz",
       "integrity": "sha512-2ym/q7HhC5K+akXkNV6Gip3oaHpbI6TsGjmcAsl7bcJ528MVbacPQeoauLFEeLXH4ulJvsxQwNDIg/kAEhFZxw==",
       "dev": true
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
+      "integrity": "sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@polka/url": {
       "version": "1.0.0-next.29",
@@ -9560,17 +9576,50 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true
     },
+    "node_modules/playwright": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
     "node_modules/playwright-core": {
       "version": "1.55.0",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
       "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
       "dev": true,
-      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/pngquant-bin": {

--- a/client/package.json
+++ b/client/package.json
@@ -11,12 +11,14 @@
     "test:keyboard": "vitest run tests/accessibility/keyboard-navigation.test.tsx",
     "audit:a11y": "node scripts/accessibility-audit.js",
     "audit:a11y:dev": "node scripts/accessibility-audit.js --dev",
-    "lhci": "lhci autorun"
+    "lhci": "lhci autorun",
+    "test:a11y:smoke": "playwright test"
   },
   "devDependencies": {
     "@axe-core/playwright": "4.10.2",
     "@axe-core/react": "4.10.2",
     "@lhci/cli": "0.14.0",
+    "@playwright/test": "^1.55.0",
     "@testing-library/jest-dom": "6.4.8",
     "@testing-library/react": "14.2.1",
     "@testing-library/user-event": "14.5.2",
@@ -44,6 +46,6 @@
     "react-i18next": "15.6.1",
     "react-router-dom": "6.28.0",
     "tailwindcss": "4.1.11",
-      "web-vitals": "5.1.0"
+    "web-vitals": "5.1.0"
   }
 }

--- a/client/playwright.config.ts
+++ b/client/playwright.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: 'tests/accessibility',
+  testMatch: /a11y-smoke\.spec\.ts/,
+  timeout: 60_000,
+  use: {
+    baseURL: 'http://localhost:5173',
+  },
+  webServer: {
+    command: 'npm run dev',
+    port: 5173,
+    reuseExistingServer: true,
+  },
+});

--- a/client/tests/accessibility/a11y-smoke.spec.ts
+++ b/client/tests/accessibility/a11y-smoke.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+const pages = ['/login', '/dashboard', '/employees'];
+
+for (const path of pages) {
+  test(`expect no serious or critical accessibility violations on ${path}`, async ({ page }) => {
+    await page.goto(path);
+    const results = await new AxeBuilder({ page }).analyze();
+    const serious = results.violations.filter(v => v.impact === 'critical' || v.impact === 'serious');
+    expect(serious).toEqual([]);
+  });
+}


### PR DESCRIPTION
## Summary
- add Playwright configuration for running accessibility tests
- add smoke test for /login, /dashboard, and /employees expecting no serious or critical violations
- include Playwright test script and dev dependency

## Testing
- `npm run test:a11y:smoke` *(fails: unresolved imports and accessibility violations)*

------
https://chatgpt.com/codex/tasks/task_e_68ab0a29f294832599ecb707e3230711