### PR TITLE
Enforce DB key and expand observability alerts

### DIFF
--- a/client/src/lib/apiRequest.ts
+++ b/client/src/lib/apiRequest.ts
@@ -78,6 +78,9 @@ export const apiRequest = async <T = unknown>(
     // Always include CSRF token via wrapped fetch
     const response = await fetchWithCsrf(url, requestOptions);
 
+    const requestId = response.headers.get('x-request-id') ?? undefined;
+    logger.dev(`API ${method} ${url}`, { status: response.status, requestId }, 'API');
+
     // Cache ETag header if present
     const etag = response.headers.get('etag');
     if (etag) {
@@ -109,6 +112,7 @@ export const apiRequest = async <T = unknown>(
 
       }
 
+      logger.error(`HTTP error! status: ${response.status} - ${response.statusText}`, { requestId });
       throw new Error(`HTTP error! status: ${response.status} - ${response.statusText}`);
 
     }
@@ -135,7 +139,7 @@ export const apiRequest = async <T = unknown>(
 
   } catch (error) {
 
-    logger.error(`API Request failed for ${url}:`, error);
+    logger.error(`API Request failed for ${url}:`, { error, requestId });
     throw error;
 
   }

--- a/monitoring/grafana/dashboards/hrms-elite-observability.json
+++ b/monitoring/grafana/dashboards/hrms-elite-observability.json
@@ -672,8 +672,77 @@
           "h": 8,
           "w": 24,
           "x": 0,
-          "y": 56
+        "y": 56
         }
+      }
+      ,
+      {
+        "id": 14,
+        "title": "Rate Limit Spikes",
+        "type": "stat",
+        "targets": [
+          {
+            "expr": "rate(http_requests_total{status=\\"429\\"}[5m])",
+            "legendFormat": "429 responses"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "color": { "mode": "thresholds" },
+            "custom": {
+              "displayMode": "gradient",
+              "orientation": "auto",
+              "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+              "showThresholdLabels": false,
+              "showThresholdMarkers": true
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                { "color": "green", "value": null },
+                { "color": "yellow", "value": 10 },
+                { "color": "red", "value": 20 }
+              ]
+            },
+            "unit": "reqps"
+          }
+        },
+        "gridPos": { "h": 8, "w": 24, "x": 0, "y": 64 }
+      },
+      {
+        "id": 15,
+        "title": "Auth Errors",
+        "type": "stat",
+        "targets": [
+          {
+            "expr": "rate(http_requests_total{status=~\\"401|403\\"}[5m])",
+            "legendFormat": "401/403 responses"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "color": { "mode": "thresholds" },
+            "custom": {
+              "displayMode": "gradient",
+              "orientation": "auto",
+              "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+              "showThresholdLabels": false,
+              "showThresholdMarkers": true
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                { "color": "green", "value": null },
+                { "color": "yellow", "value": 10 },
+                { "color": "red", "value": 20 }
+              ]
+            },
+            "unit": "reqps"
+          }
+        },
+        "gridPos": { "h": 8, "w": 24, "x": 0, "y": 72 }
       }
     ],
     "time": {

--- a/monitoring/prometheus/rules/alerts.yml
+++ b/monitoring/prometheus/rules/alerts.yml
@@ -131,6 +131,26 @@ groups:
           summary: "Slow database queries detected"
           description: "95th percentile database query time is above 1 second"
 
+      # Rate Limit Spikes
+      - alert: RateLimitSpike
+        expr: increase(http_requests_total{status="429"}[5m]) > 25
+        for: 0m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Rate limit spike detected"
+          description: "More than 25 requests were rate limited in the last 5 minutes"
+
+      # Authentication/Authorization Error Spikes
+      - alert: AuthErrorSpike
+        expr: increase(http_requests_total{status=~"401|403"}[5m]) > 25
+        for: 0m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Spike in 401/403 responses"
+          description: "More than 25 authentication or authorization errors in the last 5 minutes"
+
       # Antivirus Scan Failures
       - alert: AVScanFailure
         expr: increase(av_scan_failures_total[5m]) > 0

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "fonts:download": "node scripts/download-fonts.mjs",
     "fix-typescript-types": "node scripts/fix-typescript-types.js",
     "security-fix": "node scripts/security-fix.cjs",
-    "check:secrets": "node scripts/check-placeholder-secrets.js",
+    "check:secrets": "node scripts/check-secrets.js",
     "security:guard": "node scripts/security-ci-guard.js",
     "security:guard:production": "cross-env NODE_ENV=production node scripts/security-ci-guard.js --production",
     "security:validate": "node scripts/security-validator.js",

--- a/scripts/check-secrets.js
+++ b/scripts/check-secrets.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+import fs from 'fs';
+import { execSync } from 'child_process';
+
+const PLACEHOLDER_PATTERN = /(=|:\s*)(["']?)(default|changeme|__REPLACE_WITH_STRONG_SECRET__)(?:\2)/i;
+
+const files = execSync('git ls-files -z', { encoding: 'utf8' })
+  .split('\0')
+  .filter(Boolean)
+  .filter(f => f.startsWith('.env'));
+
+const violations = [];
+
+for (const file of files) {
+  const content = fs.readFileSync(file, 'utf8');
+  const lines = content.split(/\r?\n/);
+  lines.forEach((line, idx) => {
+    if (PLACEHOLDER_PATTERN.test(line)) {
+      violations.push(`${file}:${idx + 1} contains placeholder secret`);
+      return;
+    }
+    const match = line.match(/^([A-Z0-9_]+)\s*=\s*(.+)$/);
+    if (match) {
+      const [_, key, value] = match;
+      const cleaned = value.trim().replace(/^['"]|['"]$/g, '');
+      if ((key.includes('SECRET') || key.includes('KEY')) && cleaned && cleaned.length < 32) {
+        violations.push(`${file}:${idx + 1} ${key} is too short`);
+      }
+    }
+  });
+}
+
+if (violations.length > 0) {
+  console.error('❌ Weak or placeholder secrets detected:');
+  violations.forEach(v => console.error(` - ${v}`));
+  process.exit(1);
+}
+
+console.log('✅ Secrets check passed.');

--- a/server/index.ts
+++ b/server/index.ts
@@ -46,10 +46,7 @@ export const app = express();
 const PORT = env.PORT;
 const vitalsRateLimiter = createRateLimiter('general');
 
-if (
-  env.NODE_ENV === 'production' &&
-  (!process.env.DB_ENCRYPTION_KEY || process.env.DB_ENCRYPTION_KEY.length < 32)
-) {
+if (!process.env.DB_ENCRYPTION_KEY || process.env.DB_ENCRYPTION_KEY.length < 32) {
   throw new Error('DB_ENCRYPTION_KEY is required and must be at least 32 characters');
 }
 

--- a/server/utils/dbSecurity.ts
+++ b/server/utils/dbSecurity.ts
@@ -105,6 +105,9 @@ export class SecureDatabaseManager {
       const databasePath = dbPath || env.DATABASE_URL || 'dev.db';
 
       if (this.config.encryption.enabled) {
+        if (!this.encryptionKey || this.encryptionKey.length < 32) {
+          throw new Error('DB_ENCRYPTION_KEY is required and must be at least 32 characters');
+        }
         // Use SQLite for encrypted database
         this.database = new Database(databasePath) as any;
 


### PR DESCRIPTION
## Summary
- ensure startup fails without strong DB_ENCRYPTION_KEY
- add secrets check script for CI
- add Prometheus alerts and Grafana panels for auth and rate-limit issues
- log X-Request-ID on client API calls

## Testing
- `node scripts/check-secrets.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab1ff113788325acf4cfdd9f80ca8f