### PR TITLE
feat(db): enforce encryption fail-closed + CI guard

### DIFF
--- a/.github/workflows/ci-db-encryption.yml
+++ b/.github/workflows/ci-db-encryption.yml
@@ -1,0 +1,15 @@
+name: ci-db-encryption
+on: [push, pull_request]
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: '20' }
+      - run: |
+          key="${{ secrets.DB_ENCRYPTION_KEY }}"
+          if [ "$key" = "" ]; then
+            echo "DB_ENCRYPTION_KEY missing in secrets"; exit 1; fi
+          if [ ${#key} -lt 32 ]; then
+            echo "DB_ENCRYPTION_KEY too short"; exit 1; fi

--- a/server/bootstrap/encryption-guard.ts
+++ b/server/bootstrap/encryption-guard.ts
@@ -1,0 +1,12 @@
+export function assertDatabaseEncryption() {
+  const enabled = process.env.DB_ENCRYPTION_ENABLED?.toLowerCase() === 'true';
+  const key = process.env.DB_ENCRYPTION_KEY || '';
+  if (!enabled) {
+    console.error('[DB] Encryption is mandatory: set DB_ENCRYPTION_ENABLED=true');
+    process.exit(1);
+  }
+  if (key.length < 32) {
+    console.error('[DB] DB_ENCRYPTION_KEY must be >=32 chars');
+    process.exit(1);
+  }
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -9,6 +9,7 @@
 import express from 'express';
 import cookieParser from 'cookie-parser';
 import { createSessionMiddleware } from './utils/session';
+import { assertDatabaseEncryption } from './bootstrap/encryption-guard';
 
 // Import observability middleware
 import { observability } from './middleware/observability';
@@ -37,6 +38,9 @@ import aiRoutes from './routes/ai';
 import qualityRoutes from './routes/quality-routes';
 import { cacheControlGuard } from './middleware/cacheControl';
 
+// Enforce at-rest encryption before anything touches the DB
+assertDatabaseEncryption();
+
 // Import versioned routes
 import v1AuthRoutes from './routes/v1/auth-routes';
 import { registerEmployeeRoutes as registerV1EmployeeRoutes } from './routes/v1/employee-routes';
@@ -45,10 +49,6 @@ import { registerDocumentRoutes } from './routes/v1/document-routes';
 export const app = express();
 const PORT = env.PORT;
 const vitalsRateLimiter = createRateLimiter('general');
-
-if (!process.env.DB_ENCRYPTION_KEY || process.env.DB_ENCRYPTION_KEY.length < 32) {
-  throw new Error('DB_ENCRYPTION_KEY is required and must be at least 32 characters');
-}
 
 // Trust proxy for rate limiting
 app.set('trust proxy', 1);


### PR DESCRIPTION
## Summary
- add bootstrap guard to enforce DB encryption and key length
- invoke guard early in server entrypoint
- check DB_ENCRYPTION_KEY presence & length in CI

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab2faf428483258aa9c3ccca694ea5