### PR TITLE
fix(csp,hsts): app-owned nonce CSP; enable HSTS preload

### DIFF
--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -97,12 +97,13 @@ http {
         ssl_stapling_verify on;
         
         # Security headers
-        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
         add_header X-Frame-Options "SAMEORIGIN" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header X-XSS-Protection "1; mode=block" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data: https:; connect-src 'self'; frame-src 'none'; object-src 'none'; base-uri 'self';" always;
+        # CSP set by app with nonce; do not duplicate here to avoid mismatch
+        more_clear_headers 'Content-Security-Policy';
         
         # Root directory
         root /var/www/html;


### PR DESCRIPTION
## Summary
- delegate Content-Security-Policy header to app and clear nginx copy
- add preload to Strict-Transport-Security header

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac1d5def148325aa5aefc29c0fcf00