### PR TITLE
chore(ratelimit): stricter defaults for rate limiter

### DIFF
--- a/server/src/middleware/rate-limit.ts
+++ b/server/src/middleware/rate-limit.ts
@@ -1,0 +1,4 @@
+import rateLimit from 'express-rate-limit';
+
+export const general = rateLimit({ windowMs: 15*60*1000, limit: 60 });
+export const login = rateLimit({ windowMs: 15*60*1000, limit: 5, standardHeaders: true, legacyHeaders: false });


### PR DESCRIPTION
## Summary
- tighten general rate limiter to 60 requests per 15 minutes
- enable standard rate limit headers on login limiter

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac251111008325b25f6450ad744e58