### PR TITLE
feat(logger): add HTTP log shipping and enable alerts

### DIFF
--- a/config/prometheus-rules.yml
+++ b/config/prometheus-rules.yml
@@ -1,0 +1,163 @@
+# Prometheus alerting rules - alerts enabled
+groups:
+  - name: hrms-elite-alerts
+    rules:
+      # High CPU Usage
+      - alert: HighCPUUsage
+        expr: 100 - (avg by(instance) (irate(node_cpu_seconds_total{mode="idle"}[5m])) * 100) > 80
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High CPU usage detected"
+          description: "CPU usage is above 80% for more than 5 minutes on {{ $labels.instance }}"
+
+      # High Memory Usage
+      - alert: HighMemoryUsage
+        expr: (node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) / node_memory_MemTotal_bytes * 100 > 85
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High memory usage detected"
+          description: "Memory usage is above 85% for more than 5 minutes on {{ $labels.instance }}"
+
+      # High Disk Usage
+      - alert: HighDiskUsage
+        expr: (node_filesystem_size_bytes - node_filesystem_free_bytes) / node_filesystem_size_bytes * 100 > 90
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High disk usage detected"
+          description: "Disk usage is above 90% on {{ $labels.mountpoint }}"
+
+      # Application Down
+      - alert: HRMSApplicationDown
+        expr: up{job="hrms-elite"} == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "HRMS Elite application is down"
+          description: "HRMS Elite application has been down for more than 1 minute"
+
+      # High Response Time
+      - alert: HighResponseTime
+        expr: histogram_quantile(0.95, rate(http_request_duration_seconds_bucket[5m])) > 1
+        for: 0m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High response time detected"
+          description: "95th percentile response time is above 1 second"
+
+      # High Error Rate
+      - alert: HighErrorRate
+        expr: rate(http_requests_errors_total[5m]) / rate(http_requests_total[5m]) * 100 > 5
+        for: 0m
+        labels:
+          severity: critical
+        annotations:
+          summary: "High error rate detected"
+          description: "Error rate is above 5% for more than 5 minutes"
+
+      # Database Connection Issues
+      - alert: DatabaseConnectionIssues
+        expr: up{job="postgres-exporter"} == 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Database connection issues"
+          description: "Cannot connect to database for more than 2 minutes"
+
+      # Low Disk Space
+      - alert: LowDiskSpace
+        expr: node_filesystem_free_bytes / node_filesystem_size_bytes * 100 < 10
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Low disk space"
+          description: "Disk space is below 10% on {{ $labels.mountpoint }}"
+
+      # High Network Usage
+      - alert: HighNetworkUsage
+        expr: rate(node_network_receive_bytes_total[5m]) > 1000000000
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High network usage detected"
+          description: "Network receive rate is above 1GB/s on {{ $labels.device }}"
+
+      # Application Memory Leak
+      - alert: ApplicationMemoryLeak
+        expr: increase(process_resident_memory_bytes[1h]) > 100000000
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Potential memory leak detected"
+          description: "Application memory usage increased by more than 100MB in the last hour"
+
+      # High Login Failure Rate
+      - alert: HighLoginFailureRate
+        expr: rate(login_failures_total[5m]) > 5
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High login failure rate detected"
+          description: "Login failure rate is above 5 per minute over the last 5 minutes"
+
+      # Login 401/429 Spike
+      - alert: Login401429Spike
+        expr: increase(http_requests_total{endpoint="/api/auth/login",status=~"401|429"}[5m]) > 25
+        for: 0m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Spike in login 401/429 responses"
+          description: "Login endpoint is returning 401 or 429 responses more than 5 times per minute"
+
+      # Slow Database Queries
+      - alert: SlowDatabaseQueries
+        expr: histogram_quantile(0.95, rate(db_query_duration_seconds_bucket[5m])) > 1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Slow database queries detected"
+          description: "95th percentile database query time is above 1 second"
+
+      # Rate Limit Spikes
+      - alert: RateLimitSpike
+        expr: increase(http_requests_total{status="429"}[5m]) > 25
+        for: 0m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Rate limit spike detected"
+          description: "More than 25 requests were rate limited in the last 5 minutes"
+
+      # Authentication/Authorization Error Spikes
+      - alert: AuthErrorSpike
+        expr: increase(http_requests_total{status=~"401|403"}[5m]) > 25
+        for: 0m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Spike in 401/403 responses"
+          description: "More than 25 authentication or authorization errors in the last 5 minutes"
+
+      # Antivirus Scan Failures
+      - alert: AVScanFailure
+        expr: increase(av_scan_failures_total[5m]) > 0
+        for: 0m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Antivirus scan failure detected"
+          description: "An antivirus scan has failed in the last 5 minutes"


### PR DESCRIPTION
## Summary
- add HTTP adapter for Loki/ELK log shipping with optional correlation IDs
- include correlationId derived from req.id in all log entries
- provide Prometheus alert rules configuration

## Testing
- `npm test`
- `npx -y eslint@8 server/utils/logger.ts --max-warnings=0 --config .eslintrc.cjs -f json`


------
https://chatgpt.com/codex/tasks/task_e_68ac3a1911208325b9b979ea6ae3eded