### PR TITLE
feat: add API request helper

### DIFF
--- a/client/src/utils/apiRequest.ts
+++ b/client/src/utils/apiRequest.ts
@@ -1,0 +1,14 @@
+function getCookie(name: string): string | undefined {
+  if (typeof document === 'undefined') return undefined;
+  const match = document.cookie.match(new RegExp(`(?:^|; )${name}=([^;]*)`));
+  return match ? decodeURIComponent(match[1]) : undefined;
+}
+
+export async function apiRequest(path: string, options: RequestInit = {}): Promise<Response> {
+  const token = getCookie('X-CSRF-Token');
+  return fetch(`/api/v1${path}`, {
+    ...options,
+    credentials: options.credentials ?? 'include',
+    headers: { ...(options.headers || {}), 'X-CSRF-Token': token ?? '' }
+  });
+}


### PR DESCRIPTION
## Summary
- add API request utility that reads CSRF token from cookies and sends it with each request

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac4a5511a883259ede2d387e27d6d8