### PR TITLE
feat(pwa): avoid caching API responses

### DIFF
--- a/client/src/sw.js
+++ b/client/src/sw.js
@@ -1,0 +1,17 @@
+/* eslint-env serviceworker */
+import {clientsClaim} from 'workbox-core';
+import {precacheAndRoute} from 'workbox-precaching';
+import {registerRoute} from 'workbox-routing';
+import {CacheFirst} from 'workbox-strategies';
+
+self.skipWaiting();
+clientsClaim();
+
+// Precache assets generated during build
+precacheAndRoute(self.__WB_MANIFEST);
+
+// Cache only same-origin requests that are not API calls
+registerRoute(
+  ({url}) => url.origin === self.location.origin && !url.pathname.startsWith('/api/'),
+  new CacheFirst()
+);


### PR DESCRIPTION
## Summary
- Add Workbox service worker to precache build assets and cache same-origin requests
- Exclude `/api/` routes from service worker caching to prevent accidental API caching

## Testing
- `npm test` *(fails: test failure)*
- `cd client && npm test` *(fails: ESM import issue with @vitejs/plugin-react)*

------
https://chatgpt.com/codex/tasks/task_e_68ac531695d48325931853926d7bf54e