### PR TITLE
chore: remove moment dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,5 +4,5 @@
 - Upgrade axios to 1.11.0 for SSRF and credential leakage fix.
 - Upgrade express-session to 1.18.2, pulling in on-headers 1.1.0.
 - Override sanitize-html to 2.17.0.
-- Replace Moment.js with date-fns and remove moment dependency.
+- Remove leftover Moment.js dependency in favor of date-fns.
 - Enforce esbuild 0.25.0 via override.

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,6 @@
         "lucide-react": "0.453.0",
         "memoizee": "0.4.17",
         "memorystore": "1.6.7",
-        "moment": "2.30.1",
         "multer": "2.0.2",
         "next-themes": "0.4.6",
         "node-cron": "3.0.3",
@@ -19587,6 +19586,7 @@
       "version": "2.30.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
       "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "*"

--- a/package.json
+++ b/package.json
@@ -202,7 +202,6 @@
     "lucide-react": "0.453.0",
     "memoizee": "0.4.17",
     "memorystore": "1.6.7",
-    "moment": "2.30.1",
     "multer": "2.0.2",
     "next-themes": "0.4.6",
     "node-cron": "3.0.3",


### PR DESCRIPTION
## Summary
- remove unused Moment.js package
- document shift to date-fns for date handling

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68ac6f8ae91c8325a770b4e3edb95c29