### PR TITLE
feat(auth): expose public routes

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -42,7 +42,7 @@ import { apiVersioningRedirect } from './middleware/apiVersioningRedirect';
 assertDatabaseEncryption();
 
 // Import versioned routes
-import v1AuthRoutes from './routes/v1/auth-routes';
+import { authRoutesPublic, authRoutesPrivate } from './routes/v1/auth-routes';
 import { registerEmployeeRoutes as registerV1EmployeeRoutes } from './routes/v1/employee-routes';
 import { registerDocumentRoutes } from './routes/v1/document-routes';
 
@@ -140,7 +140,8 @@ app.get('/api-docs', (req, res) => {
 app.use(apiVersioningRedirect);
 
 // Versioned API routes
-app.use('/api/v1/auth', isAuthenticated, v1AuthRoutes);
+app.use('/api/v1/auth', authRoutesPublic);
+app.use('/api/v1/auth', isAuthenticated, authRoutesPrivate);
 registerV1EmployeeRoutes(app);
 registerDocumentRoutes(app);
 app.use('/api/v1/ai', isAuthenticated, aiRoutes);

--- a/server/routes/v1/auth-routes.ts
+++ b/server/routes/v1/auth-routes.ts
@@ -3,7 +3,6 @@ import { storage } from '../../models/storage';
 import { log } from '../../utils/logger';
 import {
   isAuthenticated,
-  optionalAuth,
   generateJWTToken,
   generateRefreshToken,
   verifyRefreshToken,
@@ -67,14 +66,15 @@ interface SessionData {
   user?: SessionUser;
 }
 
-const router = Router();
+export const authRoutesPublic = Router();
+export const authRoutesPrivate = Router();
 
 /**
  * Unified User Endpoint - Primary endpoint for all user operations
  * GET /api/v1/auth/user
  * Returns current user with company context
  */
-router.get('/user', isAuthenticated, async (req: Request, res: Response) => {
+authRoutesPrivate.get('/user', isAuthenticated, async (req: Request, res: Response) => {
   try {
     const userId = req.user!.id;
     const companyId = req.query.companyId as string;
@@ -154,7 +154,7 @@ router.get('/user', isAuthenticated, async (req: Request, res: Response) => {
  * Login endpoint
  * POST /api/v1/auth/login
  */
-router.post('/login', async (req: Request, res: Response) => {
+authRoutesPublic.post('/login', async (req: Request, res: Response) => {
   try {
     const { email, password, rememberMe } = req.body;
 
@@ -264,7 +264,7 @@ router.post('/login', async (req: Request, res: Response) => {
  * Register endpoint
  * POST /api/v1/auth/register
  */
-router.post('/register', async (req: Request, res: Response) => {
+authRoutesPublic.post('/register', async (req: Request, res: Response) => {
   try {
     const { email, password, confirmPassword, firstName, lastName, companyName, role } = req.body;
 
@@ -399,7 +399,7 @@ router.post('/register', async (req: Request, res: Response) => {
  * Logout endpoint
  * POST /api/v1/auth/logout
  */
-router.post('/logout', isAuthenticated, async (req: Request, res: Response) => {
+authRoutesPrivate.post('/logout', isAuthenticated, async (req: Request, res: Response) => {
   try {
     const refreshToken = getRefreshTokenFromRequest(req);
     
@@ -433,7 +433,7 @@ router.post('/logout', isAuthenticated, async (req: Request, res: Response) => {
  * Refresh token endpoint
  * POST /api/v1/auth/refresh
  */
-router.post('/refresh', async (req: Request, res: Response) => {
+authRoutesPublic.post('/refresh', async (req: Request, res: Response) => {
   try {
     const refreshToken = getRefreshTokenFromRequest(req);
     
@@ -527,7 +527,7 @@ router.post('/refresh', async (req: Request, res: Response) => {
  * Forgot password endpoint
  * POST /api/v1/auth/forgot-password
  */
-router.post('/forgot-password', async (req: Request, res: Response) => {
+authRoutesPublic.post('/forgot-password', async (req: Request, res: Response) => {
   try {
     const { email } = req.body;
 
@@ -593,7 +593,7 @@ router.post('/forgot-password', async (req: Request, res: Response) => {
  * Reset password endpoint
  * POST /api/v1/auth/reset-password
  */
-router.post('/reset-password', async (req: Request, res: Response) => {
+authRoutesPublic.post('/reset-password', async (req: Request, res: Response) => {
   try {
     const { token, password, confirmPassword } = req.body;
 
@@ -673,7 +673,7 @@ router.post('/reset-password', async (req: Request, res: Response) => {
  * Verify email endpoint
  * POST /api/v1/auth/verify-email
  */
-router.post('/verify-email', async (req: Request, res: Response) => {
+authRoutesPublic.post('/verify-email', async (req: Request, res: Response) => {
   try {
     const { token } = req.body;
 
@@ -729,4 +729,4 @@ router.post('/verify-email', async (req: Request, res: Response) => {
   }
 });
 
-export default router;
+export { authRoutesPublic, authRoutesPrivate };


### PR DESCRIPTION
## Summary
- split auth routes into public and private routers so login and register are accessible without authentication
- mount public auth routes before authentication middleware in server

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac75f1e1948325bc4ff04f7602191b